### PR TITLE
Unadvertise should drain before close

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
-    "tchannel": "3.0.3",
+    "tchannel": "3.1.0",
     "thriftify": "1.0.0-alpha14",
     "uber-statsd-client": "1.3.2",
     "uncaught-exception": "5.0.0",

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -354,17 +354,17 @@ function removeServicePeer(serviceName, hostPort) {
     }
 
     if (!anyOtherSubChan) {
-        var connections = peer.connections;
-        var allDrained = CountedReadySignal(connections.length);
+        var allDrained = CountedReadySignal(peer.connections.length + 1);
         allDrained(onAllDrained);
-        for (var j = 0; j < connections.length; j++) {
-            connections[j].drain('closing due to unadvertisement', allDrained.signal);
+        for (var j = 0; j < peer.connections.length; j++) {
+            peer.connections[j].drain('closing due to unadvertisement', allDrained.signal);
         }
+        allDrained.signal();
     }
 
     function onAllDrained() {
-        self.logger.info('Peer drained and closed', self.extendLogInfo({
-            hostPort: peer.hostPort
+        self.logger.info('Peer drained and closed due to unadvertisement', peer.extendLogInfo({
+            serviceName: serviceName
         }));
         peer.close(noop);
         self.channel.peers.delete(hostPort);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -28,6 +28,7 @@ var util = require('util');
 
 var RateLimiter = require('./rate_limiter.js');
 var Circuits = require('./circuits.js');
+var CountedReadySignal = require('ready-signal/counted');
 
 var DEFAULT_LOG_GRACE_PERIOD = 5 * 60 * 1000;
 var SERVICE_PURGE_PERIOD = 5 * 60 * 1000;
@@ -353,6 +354,18 @@ function removeServicePeer(serviceName, hostPort) {
     }
 
     if (!anyOtherSubChan) {
+        var connections = peer.connections;
+        var allDrained = CountedReadySignal(connections.length);
+        allDrained(onAllDrained);
+        for (var j = 0; j < connections.length; j++) {
+            connections[j].drain('closing due to unadvertisement', allDrained.signal);
+        }
+    }
+
+    function onAllDrained() {
+        self.logger.info('Peer drained and closed', self.extendLogInfo({
+            hostPort: peer.hostPort
+        }));
         peer.close(noop);
         self.channel.peers.delete(hostPort);
     }


### PR DESCRIPTION
Today, a peer and its associated connections are closed immediately after unadvertisement request is made, so the request itself fails with a connection reset error.

Now since we have graceful drain, we can decline new requests and wait for on-going requests (including unadvertisement) to finish before closing the connections.

r: @Raynos @ShanniLi @jcorbin 