### PR TITLE
larch: level routing backend; debugs skip reservoir

### DIFF
--- a/clients/logger.js
+++ b/clients/logger.js
@@ -25,8 +25,8 @@ var Logger = require('logtron');
 var process = require('process');
 
 var LarchLogger = require('../lib/larch/larch');
-var LogtronLogBackend = require('../lib/larch/logtron-backend');
-var ReservoirLogBackend = require('../lib/larch/reservoir-backend');
+var LogtronBackend = require('../lib/larch/logtron-backend');
+var ReservoirBackend = require('../lib/larch/reservoir-backend');
 var LevelRouterBackend = require('../lib/larch/level-router-backend');
 
 var Levels = {
@@ -95,18 +95,14 @@ function createLogger(options) {
         transforms: []
     });
 
-    var logtronLogBackend = LogtronLogBackend(logtronLogger);
-
-    var reservoirBackend = ReservoirLogBackend({
-        backend: logtronLogBackend
-    });
-
-    // debug logs to straight to Logtron; rest of logs are reservoir sampled
+    // debug logs sent to drop backend; rest of logs are reservoir sampled
     // then sent to Logtron
     var levelRouterBackend = LevelRouterBackend({
         backends: {
-            debug: logtronLogBackend,
-            default: reservoirBackend
+            debug: DropBackend(),
+            default: ReservoirBackend({
+                backend: LogtronBackend(logtronLogger)
+            })
         }
     });
 

--- a/clients/logger.js
+++ b/clients/logger.js
@@ -97,7 +97,8 @@ function createLogger(options) {
     });
 
     var reservoir = ReservoirBackend({
-        backend: LogtronBackend(logtronLogger)
+        backend: LogtronBackend(logtronLogger),
+        statsd: options.statsd
     });
 
     // debug logs sent to drop backend; rest of logs are reservoir sampled

--- a/clients/logger.js
+++ b/clients/logger.js
@@ -28,6 +28,7 @@ var LarchLogger = require('../lib/larch/larch');
 var LogtronBackend = require('../lib/larch/logtron-backend');
 var ReservoirBackend = require('../lib/larch/reservoir-backend');
 var LevelRouterBackend = require('../lib/larch/level-router-backend');
+var DropBackend = require('../lib/larch/drop-backend');
 
 var Levels = {
     TRACE: 10,
@@ -95,14 +96,16 @@ function createLogger(options) {
         transforms: []
     });
 
+    var reservoir = ReservoirBackend({
+        backend: LogtronBackend(logtronLogger)
+    });
+
     // debug logs sent to drop backend; rest of logs are reservoir sampled
     // then sent to Logtron
     var levelRouterBackend = LevelRouterBackend({
         backends: {
             debug: DropBackend(),
-            default: ReservoirBackend({
-                backend: LogtronBackend(logtronLogger)
-            })
+            default: reservoir
         }
     });
 
@@ -113,6 +116,6 @@ function createLogger(options) {
 
     return {
         logger: logger,
-        reservoir: reservoirBackend
+        reservoir: reservoir
     };
 }

--- a/lib/larch/base-backend.js
+++ b/lib/larch/base-backend.js
@@ -59,15 +59,11 @@ function BaseBackend(options) {
 BaseBackend.prototype.log = function log(record, cb) {};
 
 BaseBackend.prototype.bootstrap = function bootstrap(cb) {
-    if (typeof cb === 'function') {
-        cb();
-    }
+    cb();
 };
 
-BaseBackend.prototype.destroy = function bootstrap(cb) {
-    if (typeof cb === 'function') {
-        cb();
-    }
+BaseBackend.prototype.destroy = function destroy(cb) {
+    cb();
 };
 
 BaseBackend.prototype.logMany = function logMany(records, cb) {

--- a/lib/larch/base-backend.js
+++ b/lib/larch/base-backend.js
@@ -59,11 +59,15 @@ function BaseBackend(options) {
 BaseBackend.prototype.log = function log(record, cb) {};
 
 BaseBackend.prototype.bootstrap = function bootstrap(cb) {
-    cb();
+    if (typeof cb === 'function') {
+        cb();
+    }
 };
 
 BaseBackend.prototype.destroy = function bootstrap(cb) {
-    cb();
+    if (typeof cb === 'function') {
+        cb();
+    }
 };
 
 BaseBackend.prototype.logMany = function logMany(records, cb) {
@@ -76,6 +80,8 @@ BaseBackend.prototype.logMany = function logMany(records, cb) {
     }
 
     function logsDone(ignored, results) {
-        cb(Errors.resultArrayToError(results, 'larch.log-many.many-errors'));
+        if (typeof cb === 'function') {
+            cb(Errors.resultArrayToError(results, 'larch.log-many.many-errors'));
+        }
     }
 };

--- a/lib/larch/drop-backend.js
+++ b/lib/larch/drop-backend.js
@@ -39,9 +39,13 @@ function DropBackend(options) {
 util.inherits(DropBackend, BaseBackend);
 
 DropBackend.prototype.log = function log(record, cb) {
-    cb();
+    if (typeof cb === 'function') {
+        cb();
+    }
 };
 
 DropBackend.prototype.logMany = function logMany(records, cb) {
-    cb();
+    if (typeof cb === 'function') {
+        cb();
+    }
 };

--- a/lib/larch/drop-backend.js
+++ b/lib/larch/drop-backend.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var util = require('util');
+
+var BaseBackend = require('./base-backend');
+
+module.exports = DropBackend;
+
+function DropBackend(options) {
+    if (!(this instanceof DropBackend)) {
+        return new DropBackend(options);
+    }
+
+    var self = this;
+
+    BaseBackend.call(self);
+}
+
+util.inherits(DropBackend, BaseBackend);
+
+DropBackend.prototype.log = function log(record, cb) {
+    cb();
+};
+
+DropBackend.prototype.logMany = function logMany(records, cb) {
+    cb();
+};
+

--- a/lib/larch/drop-backend.js
+++ b/lib/larch/drop-backend.js
@@ -45,4 +45,3 @@ DropBackend.prototype.log = function log(record, cb) {
 DropBackend.prototype.logMany = function logMany(records, cb) {
     cb();
 };
-

--- a/lib/larch/level-router-backend.js
+++ b/lib/larch/level-router-backend.js
@@ -69,9 +69,9 @@ function LevelRouterBackend(options) {
     self.uniqueBackends = [];
 
     var i;
-    for (i = 0; i < self.backends.length; i++) {
-        if (self.uniqueBackends.indexOf(self.backends[i]) === -1) {
-            self.uniqueBackends.push(self.backends[i]);
+    for (i = 0; i < levels.length; i++) {
+        if (self.uniqueBackends.indexOf(self.backends[levels[i]]) === -1) {
+            self.uniqueBackends.push(self.backends[levels[i]]);
         }
     }
 }

--- a/lib/larch/level-router-backend.js
+++ b/lib/larch/level-router-backend.js
@@ -27,7 +27,6 @@ var util = require('util');
 var BaseBackend = require('./base-backend');
 var Errors = require('./errors');
 var Levels = require('./levels');
-var Record = require('./record');
 
 module.exports = LevelRouterBackend;
 
@@ -52,8 +51,8 @@ function LevelRouterBackend(options) {
     });
 
     assert(
-        seen === levels.length || 
-            (typeof self.backends.default === 'object' && 
+        seen === levels.length ||
+            (typeof self.backends.default === 'object' &&
             typeof self.backends.default.log === 'function'),
         'expected options.backends to have 1 backend per level or a default' +
             ' backend'
@@ -91,7 +90,7 @@ LevelRouterBackend.prototype.bootstrap = function bootstrap(cb) {
     function bootstrapsDone(ignored, results) {
         if (typeof cb === 'function') {
             cb(Errors.resultArrayToError(
-                results, 
+                results,
                 'larch.level-router-backend.bootstrap.many-errors'
             ));
         }
@@ -110,7 +109,7 @@ LevelRouterBackend.prototype.destroy = function bootstrap(cb) {
     function destroysDone(ignored, results) {
         if (typeof cb === 'function') {
             cb(Errors.resultArrayToError(
-                results, 
+                results,
                 'larch.level-router-backend.destroy.many-errors'
             ));
         }
@@ -122,4 +121,3 @@ LevelRouterBackend.prototype.log = function log(record, cb) {
 
     self.backends[record.data.level].log(record, cb);
 };
-

--- a/lib/larch/level-router-backend.js
+++ b/lib/larch/level-router-backend.js
@@ -1,0 +1,125 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var collectParallel = require('collect-parallel/array');
+var util = require('util');
+
+var BaseBackend = require('./base-backend');
+var Errors = require('./errors');
+var Levels = require('./levels');
+var Record = require('./record');
+
+module.exports = LevelRouterBackend;
+
+function LevelRouterBackend(options) {
+    if (!(this instanceof LevelRouterBackend)) {
+        return new LevelRouterBackend(options);
+    }
+
+    var self = this;
+
+    BaseBackend.call(self);
+
+    self.backends = options.backends;
+    assert(
+        typeof self.backends === 'object',
+        'options.backends must be object'
+    );
+
+    var levels = Object.keys(Levels.BY_NAME);
+    var seen = levels.filter(function f(item) {
+        return item in self.backends;
+    });
+
+    assert(
+        seen === levels.length || 
+            (typeof self.backends.default === 'object' && 
+            typeof self.backends.default.log === 'function'),
+        'expected options.backends to have 1 backend per level or a default' +
+            ' backend'
+    );
+
+    if (self.backends.default) {
+        levels.forEach(function e(level) {
+            if (!self.backends[level]) {
+                self.backends[level] = self.backends.default;
+            }
+        });
+    }
+
+    self.uniqueBackends = [];
+
+    var i;
+    for (i = 0; i < self.backends.length; i++) {
+        if (self.uniqueBackends.indexOf(self.backends[i]) === -1) {
+            self.uniqueBackends.push(self.backends[i]);
+        }
+    }
+}
+
+util.inherits(LevelRouterBackend, BaseBackend);
+
+LevelRouterBackend.prototype.bootstrap = function bootstrap(cb) {
+    var self = this;
+
+    collectParallel(self.uniqueBackends, bootstrapBackend, bootstrapsDone);
+
+    function bootstrapBackend(backend, i, backendCb) {
+        backend.bootstrap(backendCb);
+    }
+
+    function bootstrapsDone(ignored, results) {
+        if (typeof cb === 'function') {
+            cb(Errors.resultArrayToError(
+                results, 
+                'larch.level-router-backend.bootstrap.many-errors'
+            ));
+        }
+    }
+};
+
+LevelRouterBackend.prototype.destroy = function bootstrap(cb) {
+    var self = this;
+
+    collectParallel(self.uniqueBackends, destroyBackend, destroysDone);
+
+    function destroyBackend(backend, i, backendCb) {
+        backend.destroy(backendCb);
+    }
+
+    function destroysDone(ignored, results) {
+        if (typeof cb === 'function') {
+            cb(Errors.resultArrayToError(
+                results, 
+                'larch.level-router-backend.destroy.many-errors'
+            ));
+        }
+    }
+};
+
+LevelRouterBackend.prototype.log = function log(record, cb) {
+    var self = this;
+
+    self.backends[record.data.level].log(record, cb);
+};
+

--- a/test/larch/level-router-backend.js
+++ b/test/larch/level-router-backend.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+
+var LevelRouterBackend = require('../../lib/larch/level-router-backend');
+var Record = require('../../lib/larch/record');
+
+var FakeBackend = require('../lib/fake-backend');
+
+test('LevelRouterBackend correctly categorizes logs', function t1(assert) {
+    var debugBackend = FakeBackend();
+    var errorBackend = FakeBackend();
+    var defaultBackend = FakeBackend();
+
+    var levelRouter = LevelRouterBackend({
+        backends: {
+            debug: debugBackend,
+            error: errorBackend,
+            default: defaultBackend
+        }
+    });
+
+    levelRouter.bootstrap(noop);
+
+    levelRouter.log(new Record('error', 'error1', {}));
+    levelRouter.log(new Record('error', 'error2', {}));
+    levelRouter.log(new Record('debug', 'debug1', {}));
+    levelRouter.log(new Record('debug', 'debug2', {}));
+    levelRouter.log(new Record('info', 'info1', {}));
+    levelRouter.log(new Record('info', 'info2', {}));
+
+    assert.ok(debugBackend.logs.length === 2, 'debug backend got 2 logs');
+    assert.ok(errorBackend.logs.length === 2, 'error backend got 2 logs');
+    assert.ok(defaultBackend.logs.length === 2, 'default backend got 2 logs');
+
+    assert.ok(
+        debugBackend.logs[0].data.message === 'debug1',
+        'debugBackend.logs[0] is correct'
+    );
+    assert.ok(
+        debugBackend.logs[1].data.message === 'debug2',
+        'debugBackend.logs[1] is correct'
+    );
+
+    assert.ok(
+        errorBackend.logs[0].data.message === 'error1',
+        'errorBackend.logs[0] is correct'
+    );
+    assert.ok(
+        errorBackend.logs[1].data.message === 'error2',
+        'errorBackend.logs[1] is correct'
+    );
+
+    assert.ok(
+        defaultBackend.logs[0].data.message === 'info1',
+        'defaultBackend.logs[0] is correct'
+    );
+    assert.ok(
+        defaultBackend.logs[1].data.message === 'info2',
+        'defaultBackend.logs[1] is correct'
+    );
+
+    assert.end();
+});
+
+function noop() {}


### PR DESCRIPTION
r: @Raynos @jcorbin 

Adds a new Larch backend called `LevelRouterBackend` which routes to a set of Larch backends based on level. Debugs will skip the reservoir and go straight to Logtron to be written to disk; all other logs will be sent to the reservoir to be sampled, then sent to Logtron.