### PR TITLE
Eliminate error log noise around declined advertises

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -352,13 +352,10 @@ function logError(err, opts, response) {
         error: err
     };
 
-    var codeName = Errors.classify(err);
-    if (codeName === 'NetworkError' ||
-        codeName === 'Timeout'
-    ) {
-        logger.warn('Relay advertise failed with expected err', logOptions);
-    } else {
+    if (Errors.isFatal(err)) {
         logger.error('Relay advertise failed with unexpected err', logOptions);
+    } else {
+        logger.warn('Relay advertise failed with expected err', logOptions);
     }
 };
 

--- a/handler.js
+++ b/handler.js
@@ -348,8 +348,8 @@ function logError(err, opts, response) {
     var logOptions = {
         exitNode: opts.hostPort,
         services: opts.services,
-        error: err,
-        responseBody: response && response.body
+        responseBody: response && response.body,
+        error: err
     };
 
     var codeName = Errors.classify(err);

--- a/handler.js
+++ b/handler.js
@@ -343,17 +343,16 @@ HyperbahnHandler.prototype.logError =
 function logError(err, opts, response) {
     var self = this;
 
-    var codeName = Errors.classify(err);
     var logger = self.channel.logger;
 
     var logOptions = {
         exitNode: opts.hostPort,
         services: opts.services,
         error: err,
-        codeName: codeName,
         responseBody: response && response.body
     };
 
+    var codeName = Errors.classify(err);
     if (codeName === 'NetworkError' ||
         codeName === 'Timeout'
     ) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
-    "tchannel": "3.2.3",
+    "tchannel": "3.2.4",
     "thriftify": "1.0.0-alpha14",
     "uber-statsd-client": "1.3.2",
     "uncaught-exception": "5.0.0",


### PR DESCRIPTION
Towards deploy confidence, uses the new `tchannel/errors.isFatal(err)` predicate from https://github.com/uber/tchannel-node/pull/34.

@kriskowal @Raynos 