### PR TITLE
make ringpop more resilient to DDOSing itself

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -36,7 +36,7 @@
 
     "hyperbahn.ringpop.timeouts": {
         "pingReqTimeout": 3000,
-        "pingTimeout": 100,
+        "pingTimeout": 500,
         "joinTimeout": 250
     },
     "hyperbahn.ringpop.bootstrapFile": "/etc/hyperbahn/ringpop-v2.json",


### PR DESCRIPTION
Turns out that pingReq is expensive.

Turns out having a higher ping latency gets us more 9999s

r: @jcorbin @rf

cc: @jwolski @danielheller