### PR TITLE
Improved hyperbahn local starter script. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ To use a service over Hyperbahn:
 
  - `git clone git@github.com:uber/hyperbahn`
  - `cd hyperbahn`
- - `npm install`
- - `npm install tcurl --global`
  - `./hyperbahn-dev.sh`
 
 This will spawn a 3 window tmux session with a two-node hyperbahn
-cluster running. The third window runs the health checks of both
-nodes to double check that the hyperbahn cluster is healthy.
+cluster running. It will also run `npm install` if necessary and install
+tcurl globally if possible and fallback to local installation if the npm
+global folder is not writeable. The third window runs the health checks
+of both nodes using tcurl to double check that the hyperbahn cluster is
+healthy.
 
 To exit run `tmux kill-session -t hyperbahn` in a seperate shell.
 

--- a/hyperbahn-dev.sh
+++ b/hyperbahn-dev.sh
@@ -1,24 +1,32 @@
 #!/bin/sh 
 set -e
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 H0="127.0.0.1:21300"
 H1="127.0.0.1:21301"
 
-if [ ! -d ./node_modules ]; then
+if [ ! -d $DIR/node_modules ]; then
   npm install
 fi
 
-./setup-dotfiles.sh $H0 $H1
+export LOCAL_BIN=$DIR/node_modules/.bin
+
+if [ ! -w `npm config get prefix` ]; then
+    command -v tcurl >/dev/null 2>&1 || npm install tcurl --global
+else
+    command -v $LOCAL_BIN/tcurl >/dev/null 2>&1 || npm install tcurl 
+fi
+
+$DIR/setup-dotfiles.sh $H0 $H1
 
 tmux new-session -s 'hyperbahn' -n 'hyperbahn-0' \; \
     new-window -n 'hyperbahn-1' \; \
     new-window -n 'hyperbahn-adhoc' \; \
-    select-window -t hyperbahn-0 \; \
-    send-keys 'make run-local-0' Enter \; \
-    select-window -t hyperbahn-1 \; \
-    send-keys 'make run-local-1' Enter \; \
+    send -t hyperbahn-0 'make run-local-0' Enter \; \
+    send -t hyperbahn-1 'make run-local-1' Enter \; \
     select-window -t hyperbahn-adhoc \; \
-    send-keys "sleep 1; tcurl -p $H0 autobahn health_v1" Enter \; \
-    send-keys "tcurl -p $H1 autobahn health_v1" Enter \; \
-    send-keys "tcurl autobahn health_v1" Enter \; \
-    attach
+    send 'sleep 1; command -v $LOCAL_BIN/tcurl >/dev/null 2>&1 && export PATH=$LOCAL_BIN:$PATH' Enter \; \
+    send "tcurl -p $H0 autobahn health_v1" Enter \; \
+    send "tcurl -p $H1 autobahn health_v1" Enter \; \
+    send "tcurl autobahn health_v1" Enter

--- a/hyperbahn-dev.sh
+++ b/hyperbahn-dev.sh
@@ -1,14 +1,24 @@
 #!/bin/sh 
 set -e
 
+H0="127.0.0.1:21300"
+H1="127.0.0.1:21301"
+
+if [ ! -d ./node_modules ]; then
+  npm install
+fi
+
+./setup-dotfiles.sh $H0 $H1
+
 tmux new-session -s 'hyperbahn' -n 'hyperbahn-0' \; \
     new-window -n 'hyperbahn-1' \; \
     new-window -n 'hyperbahn-adhoc' \; \
-    select-window -t:0 \; \
+    select-window -t hyperbahn-0 \; \
     send-keys 'make run-local-0' Enter \; \
-    select-window -t:1 \; \
+    select-window -t hyperbahn-1 \; \
     send-keys 'make run-local-1' Enter \; \
-    select-window -t:2 \; \
-    send-keys 'sleep 1; tcurl -p 127.0.0.1:21300 autobahn health_v1' Enter \; \
-    send-keys 'tcurl -p 127.0.0.1:21301 autobahn health_v1' Enter \; \
+    select-window -t hyperbahn-adhoc \; \
+    send-keys "sleep 1; tcurl -p $H0 autobahn health_v1" Enter \; \
+    send-keys "tcurl -p $H1 autobahn health_v1" Enter \; \
+    send-keys "tcurl autobahn health_v1" Enter \; \
     attach

--- a/setup-dotfiles.sh
+++ b/setup-dotfiles.sh
@@ -1,0 +1,26 @@
+#!/bin/sh 
+set -e
+
+HOSTS=$@
+
+HYPERBAHN_HOSTS_JSON=$HOME/.hyperbahn-hosts.json
+TCURLRC=$HOME/.tcurlrc;
+
+# comma and newline separated quoted list with 4-space indent
+HOSTS_CSV=$(printf -- "    \"%s\",\n" ${HOSTS[*]} | sed '$s/\,//')
+
+if [ ! -f $HYPERBAHN_HOSTS_JSON ]; then
+cat << EOF > $HYPERBAHN_HOSTS_JSON
+[
+$HOSTS_CSV
+]
+EOF
+fi
+
+if [ ! -f $TCURLRC ]; then
+cat << EOF > $TCURLRC
+{
+    "hostlist": "$HYPERBAHN_HOSTS_JSON"
+}
+EOF
+fi


### PR DESCRIPTION
Use window names instead of window indices.
Write ~/.hyperbahn-hosts.json file and a ~/tcurlrc file pointing to that hostlist.
