### PR TITLE
better stats for per worker rps

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -187,10 +187,12 @@ ServiceDispatchHandler.prototype.rateLimit =
 function rateLimit(req, buildRes) {
     var self = this;
 
-    // stats edge traffic
-    self.rateLimiter.incrementEdgeCounter(req.headers.cn + '~~' + req.serviceName);
-
     var isExitNode = self.isExitFor(req.serviceName);
+    var role = isExitNode ? 'exit' : 'entry';
+
+    // stats edge traffic
+    self.rateLimiter.incrementEdgeCounter(req.headers.cn + '.' + req.serviceName + '.' + role);
+
     if (isExitNode) {
         self.rateLimiter.createServiceCounter(req.serviceName);
         self.rateLimiter.createKillSwitchServiceCounter(req.serviceName);

--- a/test/hyperbahn-client/rate-limiter.js
+++ b/test/hyperbahn-client/rate-limiter.js
@@ -99,7 +99,7 @@ function runTests(HyperbahnCluster) {
                         assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 3, 'total request');
                         assert.equals(relayChannel.handler.rateLimiter.serviceCounters.steve.rps, 3, 'request for steve');
                         assert.equals(relayChannel.handler.rateLimiter.ksCounters.steve.rps, 3, 'request for steve - kill switch');
-                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'].rps, 3, 'request for bob~~steve');
+                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob.steve.exit'].rps, 3, 'request for bob.steve');
                     });
                     done();
                 },
@@ -110,7 +110,7 @@ function runTests(HyperbahnCluster) {
                         assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 0, 'total request');
                         assert.equals(relayChannel.handler.rateLimiter.serviceCounters.steve.rps, 0, 'request for steve');
                         assert.equals(relayChannel.handler.rateLimiter.ksCounters.steve.rps, 0, 'request for steve - kill switch');
-                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'], undefined, 'bob~~steve gets removed');
+                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob.steve.exit'], undefined, 'bob.steve gets removed');
                     });
                     done();
                 }
@@ -165,7 +165,7 @@ function runTests(HyperbahnCluster) {
                         assert.equals(rateLimiter.totalRequestCounter.rps, 3, 'check1: total request');
                         assert.equals(rateLimiter.serviceCounters.steve.rps, 3, 'check1: request for steve');
                         assert.equals(rateLimiter.ksCounters.steve.rps, 3, 'check1: request for steve - kill switch');
-                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'].rps, 3, 'check1: request for bob~~steve');
+                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob.steve.exit'].rps, 3, 'check1: request for bob.steve');
                     });
                     done();
                 },
@@ -179,7 +179,7 @@ function runTests(HyperbahnCluster) {
                         assert.equals(rateLimiter.totalRequestCounter.rps, 2, 'check2: total request');
                         assert.equals(rateLimiter.serviceCounters.steve.rps, 2, 'check2: request for steve');
                         assert.equals(rateLimiter.ksCounters.steve.rps, 2, 'check2: request for steve - kill switch');
-                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'].rps, 2, 'check2: request for bob~~steve');
+                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob.steve.exit'].rps, 2, 'check2: request for bob.steve');
                     });
                     done();
                 }


### PR DESCRIPTION
r @Raynos @kriskowal @jcorbin 

The current per worker rps is not accurate because it cuts off when rate limit is reached. 