### PR TITLE
Remove feature for testing circuits for a single service

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -329,7 +329,6 @@ ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdat
     var self = this;
     self.updateLazyHandling();
     self.updateCircuitsEnabled();
-    self.updateCircuitTestServiceName();
     self.updateRateLimitingEnabled();
     self.updateTotalRpsLimit();
     self.updateExemptServices();
@@ -363,16 +362,6 @@ ApplicationClients.prototype.updateCircuitsEnabled = function updateCircuitsEnab
         self.serviceProxy.enableCircuits();
     } else {
         self.serviceProxy.disableCircuits();
-    }
-};
-
-ApplicationClients.prototype.updateCircuitTestServiceName = function updateCircuitTestServiceName() {
-    var self = this;
-    var serviceName = self.remoteConfig.get('circuits.testServiceName', null);
-    if (serviceName) {
-        self.serviceProxy.enableCircuitTestService(serviceName);
-    } else {
-        self.serviceProxy.disableCircuitTestService();
     }
 };
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -61,7 +61,6 @@ function ServiceDispatchHandler(options) {
     self.circuitsEnabled = false;
     self.circuitsConfig = options.circuitsConfig;
     self.circuits = null;
-    self.circuitTestServiceName = null;
     self.boundOnCircuitStateChange = onCircuitStateChange;
     if (self.circuitsConfig && self.circuitsConfig.enabled) {
         self.enableCircuits();
@@ -315,11 +314,9 @@ function createServiceChannel(serviceName) {
         }
     }
 
-    var circuitEnabled = self.circuitsEnabled || self.circuitTestServiceName === serviceName;
-
     svcchan.handler = new RelayHandler(
         svcchan,
-        mode === 'exit' && circuitEnabled && self.circuits);
+        mode === 'exit' && self.circuitsEnabled && self.circuits);
 
     return svcchan;
 };
@@ -831,49 +828,6 @@ function disableCircuits() {
             subChannel.handler.circuits = null;
         }
     }
-};
-
-// To try out circuit breaking with just one service.
-ServiceDispatchHandler.prototype.enableCircuitTestService =
-function enableCircuitTestService(serviceName) {
-    var self = this;
-
-    if (self.circuitTestServiceName !== null) {
-        self.disableCircuitTestService();
-    }
-
-    // for the subchannel if it exists already:
-    var subChannel = self.channel.subChannel[serviceName];
-    if (subChannel &&
-        subChannel.handler.type === 'tchannel.relay-handler' &&
-        subChannel.serviceProxymode === 'exit'
-    ) {
-        subChannel.handler.circuits = self.circuits;
-    }
-
-    // for subsequently added subchannels with the given service name:
-    self.circuitTestServiceName = serviceName;
-};
-
-ServiceDispatchHandler.prototype.disableCircuitTestService =
-function disableCircuitTestService() {
-    var self = this;
-
-    if (self.circuitTestServiceName === null) {
-        return;
-    }
-
-    // for the subchannel if it exists already:
-    var subChannel = self.channel.subChannel[self.circuitTestServiceName];
-    if (subChannel &&
-        subChannel.handler.type === 'tchannel.relay-handler' &&
-        subChannel.serviceProxymode === 'exit'
-    ) {
-        subChannel.handler.circuits = null;
-    }
-
-    // to ensure the circuit is not enabled for subsuequently created channels:
-    self.circuitTestServiceName = null;
 };
 
 ServiceDispatchHandler.prototype.enableRateLimiter =


### PR DESCRIPTION
This turned out to be unnecessary and we never used it.