### PR TITLE
Make relay ad faster

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -152,6 +152,7 @@ function sendRelays(req, arg2, arg3, endpoint, cb) {
             continue;
         }
 
+        // TODO: cache / use sub-channel peers
         var exitNodes = self.egressNodes.exitsFor(serviceName);
         var exitHosts = Object.keys(exitNodes);
 

--- a/handler.js
+++ b/handler.js
@@ -247,20 +247,7 @@ function handleRelay(endpoint, req, arg2, arg3, cb) {
 
     for (var i = 0; i < services.length; i++) {
         var service = services[i];
-
-        var exitNodes = self.egressNodes
-            .exitsFor(service.serviceName);
-        var exitHosts = Object.keys(exitNodes);
-
-        var myHost = self.channel.hostPort;
-        if (exitHosts.indexOf(myHost) < 0) {
-            logger.warn('Non-exit node got relay', {
-                endpoint: endpoint,
-                service: service,
-                myHost: myHost,
-                exitHosts: exitHosts
-            });
-        } else if (endpoint === 'ad') {
+        if (endpoint === 'ad') {
             self.advertise(service);
         } else if (endpoint === 'unad') {
             self.unadvertise(service);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -429,7 +429,8 @@ function refreshServicePeer(serviceName, hostPort) {
     self.exitServices[serviceName] = time;
 
     if (self.partialAffinityEnabled) {
-        return self.refreshServicePeerPartially(serviceName, hostPort);
+        self.refreshServicePeerPartially(serviceName, hostPort);
+        return;
     }
 
     // The old way: fully connect every egress to all affine peers.

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -416,6 +416,15 @@ ServiceDispatchHandler.prototype.refreshServicePeer =
 function refreshServicePeer(serviceName, hostPort) {
     var self = this;
 
+    var chan = self.channel.subChannels[serviceName];
+    if (!chan) {
+        chan = self.createServiceChannel(serviceName);
+    }
+    if (chan.serviceProxyMode !== 'exit') {
+        // TODO: stat, log
+        return;
+    }
+
     // Create a peer for the worker.
     // This is necessary for populating the worker pool regardless of whether
     // we connect.


### PR DESCRIPTION
- stop doing expensive exit nodes lookup for safety
- instead do safety check within service proxy on channel mode

r @Raynos @kriskowal @rf 