### PR TITLE
switch for lazy relaying

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -341,7 +341,17 @@ ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdat
 ApplicationClients.prototype.updateLazyHandling = function updateLazyHandling() {
     var self = this;
     var enabled = self.remoteConfig.get('lazy.handling.enabled', false);
-    self.tchannel.setLazyHandling(enabled);
+    self.tchannel.setLazyRelaying(enabled);
+
+    if (enabled === false) {
+        self.tchannel.timers.setTimeout(turnOffLazyHandling, 30000);
+    } else {
+        self.tchannel.setLazyHandling(enabled);
+    }
+
+    function turnOffLazyHandling() {
+        self.tchannel.setLazyHandling(enabled);
+    }
 };
 
 ApplicationClients.prototype.updateReservoir = function updateReservoir() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -141,7 +141,9 @@ function ApplicationClients(options) {
         connectionStalePeriod: 1.5 * 1000,
         trace: false,
         logger: self.logger,
-        statsd: self.statsd
+        statsd: self.statsd,
+        useLazyRelaying: false,
+        useLazyHandling: false
     });
 
     self.autobahnHostPortList = self.loadHostList();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
-    "tchannel": "3.5.1",
+    "tchannel": "3.5.3",
     "thriftify": "1.0.0-alpha14",
     "uber-statsd-client": "1.4.0",
     "uncaught-exception": "5.0.0",

--- a/test/hyperbahn-client/rate-limiter-lazy.js
+++ b/test/hyperbahn-client/rate-limiter-lazy.js
@@ -103,6 +103,17 @@ function runTests(HyperbahnCluster) {
                         assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'].rps, 3, 'request for bob~~steve');
                     });
                     done();
+                },
+                waitFor(1000),
+                function check2(done) {
+                    cluster.apps.forEach(function check(app) {
+                        var relayChannel = app.clients.tchannel;
+                        assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 0, 'total request');
+                        assert.equals(relayChannel.handler.rateLimiter.serviceCounters.steve.rps, 0, 'request for steve');
+                        assert.equals(relayChannel.handler.rateLimiter.ksCounters.steve.rps, 0, 'request for steve - kill switch');
+                        assert.equals(relayChannel.handler.rateLimiter.edgeCounters['bob~~steve'], undefined, 'bob~~steve gets removed');
+                    });
+                    done();
                 }
             ], function done() {
                 steveHyperbahnClient.destroy();


### PR DESCRIPTION
fix the flipr flag `lazy.handling.enabled` to also flip lazy relaying as well, and delay turning off lazy handling by 30s when switching off

r @jcorbin @Raynos 