### PR TITLE
Test the lazy relay feature in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: node_js
 node_js:
   - "0.10"
 before_install: npm i npm@latest -g
+env:
+# Get some of them configs
+- HYPERBAHN_REMOTE_TEST_CONFIG=
+- HYPERBAHN_REMOTE_TEST_CONFIG=test/config/with_lazy_relay.json
 script: npm run travis

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -124,6 +124,7 @@ function handleLazily(conn, reqFrame) {
     var self = this;
 
     /*eslint max-statements: [2, 45]*/
+    /*eslint complexity: [2, 15]*/
 
     var res = reqFrame.bodyRW.lazy.readService(reqFrame);
     if (res.err) {

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -168,6 +168,11 @@ function handleLazily(conn, reqFrame) {
         return false;
     }
 
+    if (self.isBlocked(cn, serviceName)) {
+        conn.ops.popInReq(reqFrame.id);
+        return null;
+    }
+
     if (self.rateLimiterEnabled) {
         var rateLimitReason = self.rateLimit(cn, serviceName);
 

--- a/test/config/with_lazy_relay.json
+++ b/test/config/with_lazy_relay.json
@@ -1,0 +1,3 @@
+{
+    "lazy.handling.enabled": true
+}

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -36,6 +36,7 @@ var inherits = require('util').inherits;
 var nodeAssert = require('assert');
 var TChannelJSON = require('tchannel/as/json');
 var tapeCluster = require('tape-cluster');
+var extend = require('xtend');
 
 var TCReporter = require('tchannel/tcollector/reporter');
 var loadTChannelTestConfig = require('tchannel/test/lib/load_config.js');
@@ -52,6 +53,23 @@ if (process.env.TCHANNEL_TEST_CONFIG) {
             if (i === 0) {
                 console.log(
                     '# TestCluster using test channel config overlay from %s: %s',
+                    process.env.TCHANNEL_TEST_CONFIG,
+                    line);
+            } else {
+                console.log('# %s', line);
+            }
+        });
+}
+
+var remoteConfigOverlay = null;
+if (process.env.HYPERBAHN_REMOTE_TEST_CONFIG) {
+    remoteConfigOverlay = loadTChannelTestConfig(process.env.HYPERBAHN_REMOTE_TEST_CONFIG);
+    JSON.stringify(channelTestConfigOverlay, null, 4)
+        .split('\n')
+        .forEach(function each(line, i) {
+            if (i === 0) {
+                console.log(
+                    '# TestCluster using remote config overlay from %s: %s',
                     process.env.TCHANNEL_TEST_CONFIG,
                     line);
             } else {
@@ -378,6 +396,12 @@ function createApplication(hostPort, cb) {
     var rateLimiterBuckets;
     var remoteConfigFile;
     var defaultTotalKillSwitchBuffer;
+
+    self.opts.remoteConfig = self.opts.remoteConfig || {};
+    if (remoteConfigOverlay) {
+        self.opts.remoteConfig = extend(remoteConfigOverlay, self.opts.remoteConfig);
+    }
+
     if (self.opts.remoteConfig) {
         remoteConfigFile = RemoteConfigFile(hostPort);
         remoteConfigFile.write(self.opts.remoteConfig);


### PR DESCRIPTION
This adds the travis ENV variable trick to run the
test suite fully in multiple permutations of remote
configs.

I also fixed the kill switch as that was broken.

r: @jcorbin @kriskowal