### PR TITLE
Support spawning multiple workers in a seperate process

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -2,9 +2,18 @@ torch-relay-bench:
 	node index.js --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
 		-- --relay --skipPing -s 4096,16384 -p 10000,20000
 
+torch-relay-multi-bench:
+	node index.js --multi --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
+		-- --relay --skipPing -s 4096,16384 -p 100,200
+
 take-relay:
 	node index.js --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
 		-- --relay --skipPing -m 3 -s 4096,16384 -p 10000,20000
+	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
+
+take-relay-multi:
+	node index.js --multi --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
+		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,2000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 
 kill-dead-benchmarks:

--- a/benchmarks/hyperbahn-multi-worker.js
+++ b/benchmarks/hyperbahn-multi-worker.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var parseArgs = require('minimist');
+var process = require('process');
+
+var HyperbahnWorker = require('./hyperbahn-worker.js');
+
+function HyperbahnMultiWorker(opts) {
+    if (!(this instanceof HyperbahnMultiWorker)) {
+        return new HyperbahnMultiWorker(opts);
+    }
+
+    var self = this;
+
+    self.multiInstances = opts.multiInstances;
+
+    self.workers = [];
+    for (var i = 0; i < self.multiInstances; i++) {
+        var workerPort = Number(opts.workerPort) + (i + 1);
+
+        self.workers.push(HyperbahnWorker({
+            statsdPort: opts.statsdPort,
+            kafkaPort: opts.kafkaPort,
+            sentryPort: opts.sentryPort,
+            ringpopList: opts.ringpopList,
+            serverPort: opts.serverPort,
+            instances: opts.instances,
+            serverServiceName: opts.serverServiceName,
+            workerPort: workerPort
+        }));
+    }
+}
+
+HyperbahnMultiWorker.prototype.start = function start() {
+    var self = this;
+
+    for (var i = 0; i < self.workers.length; i++) {
+        self.workers[i].start();
+    }
+};
+
+if (require.main === module) {
+    var argv = parseArgs(process.argv.slice(2));
+    process.title = 'nodejs-benchmarks-hyperbahn_multi_worker';
+
+    var worker = HyperbahnMultiWorker(argv);
+
+    // attach before throwing exception
+    process.on('uncaughtException', worker.workers[0].app.clients.onError);
+    worker.start();
+}

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -28,6 +28,8 @@ var StaticConfig = require('static-config');
 
 var HyperbahnApplication = require('../app.js');
 
+module.exports = HyperbahnWorker;
+
 function HyperbahnWorker(opts) {
     /*eslint max-statements: [2, 25]*/
     if (!(this instanceof HyperbahnWorker)) {

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -108,6 +108,7 @@ HyperbahnWorker.prototype.createConfig = function createConfig() {
                 leafPort: self.kafkaPort
             },
             'clients.logtron.logFile': null,
+            // 'clients.logtron.console': true,
             'clients.logtron.sentry': {
                 id: 'http://bs:bs@localhost:' + self.sentryPort
             },

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -65,9 +65,6 @@ function HyperbahnWorker(opts) {
 HyperbahnWorker.prototype.start = function start() {
     var self = this;
 
-    // attach before throwing exception
-    process.on('uncaughtException', self.app.clients.onError);
-
     self.app.bootstrapAndListen(onAppReady);
 
     function onAppReady(err) {
@@ -123,5 +120,8 @@ if (require.main === module) {
     process.title = 'nodejs-benchmarks-hyperbahn_worker';
 
     var worker = HyperbahnWorker(argv);
+
+    // attach before throwing exception
+    process.on('uncaughtException', worker.app.clients.onError);
     worker.start();
 }

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -49,6 +49,7 @@ function HyperbahnWorker(opts) {
     self.statsdPort = Number(opts.statsdPort);
     self.kafkaPort = Number(opts.kafkaPort);
     self.sentryPort = Number(opts.sentryPort);
+    self.ringpopList = opts.ringpopList ? opts.ringpopList.split(',') : [];
     self.config = self.createConfig();
     self.app = HyperbahnApplication(self.config, {
         processTitle: process.title,
@@ -110,7 +111,8 @@ HyperbahnWorker.prototype.createConfig = function createConfig() {
             'clients.logtron.sentry': {
                 id: 'http://bs:bs@localhost:' + self.sentryPort
             },
-            'tchannel.host': '127.0.0.1'
+            'tchannel.host': '127.0.0.1',
+            'hyperbahn.ringpop.bootstrapFile': self.ringpopList
         }
     });
 };

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -107,6 +107,7 @@ HyperbahnWorker.prototype.createConfig = function createConfig() {
                 leafHost: '127.0.0.1',
                 leafPort: self.kafkaPort
             },
+            'clients.logtron.logFile': null,
             'clients.logtron.sentry': {
                 id: 'http://bs:bs@localhost:' + self.sentryPort
             },

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -93,6 +93,7 @@ function spawnHyperbahnProc(procOpts) {
     var self = this;
 
     var hyperbahnProc = self.run(bahn, procOpts);
+    var relayIndex = self.relayProcs.length;
     self.relayProcs.push(hyperbahnProc);
     hyperbahnProc.stdout.pipe(process.stderr);
     hyperbahnProc.stderr.pipe(process.stderr);
@@ -106,6 +107,8 @@ function spawnHyperbahnProc(procOpts) {
         console.error('set kill timer for %s[%s] in %sms',
                       bahn, hyperbahnProc.pid, self.opts.relayKillIn);
     }
+
+    return relayIndex;
 };
 
 HyperbahnBenchmarkRunner.prototype.close = function close() {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -34,6 +34,8 @@ var BenchmarkRunner = require('tchannel/benchmarks/');
 
 var bahn = path.join(__dirname, 'hyperbahn-worker.js');
 
+var RELAY_SERVER_PORT = 7200;
+
 function HyperbahnBenchmarkRunner(opts) {
     if (!(this instanceof HyperbahnBenchmarkRunner)) {
         return new HyperbahnBenchmarkRunner(opts);
@@ -41,6 +43,8 @@ function HyperbahnBenchmarkRunner(opts) {
 
     var self = this;
     BenchmarkRunner.call(self, opts);
+
+    self.ports.relayServerPort = RELAY_SERVER_PORT;
 }
 util.inherits(HyperbahnBenchmarkRunner, BenchmarkRunner);
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -75,7 +75,7 @@ function spawnRelayServer() {
     self.startFakeKafka();
     self.startFakeSentry();
 
-    var hyperbahnProc = self.run(bahn, [
+    var procOpts = [
         '--serverPort', String(self.ports.serverPort),
         '--serverServiceName', String(self.serviceName),
         '--instances', String(self.instanceCount),
@@ -83,7 +83,9 @@ function spawnRelayServer() {
         '--statsdPort', String(self.ports.statsdPort),
         '--kafkaPort', String(self.kafka.port),
         '--sentryPort', String(self.sentry.address().port)
-    ]);
+    ];
+
+    var hyperbahnProc = self.run(bahn, procOpts);
     self.relayProcs.push(hyperbahnProc);
     hyperbahnProc.stdout.pipe(process.stderr);
     hyperbahnProc.stderr.pipe(process.stderr);

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -85,7 +85,11 @@ function spawnRelayServer() {
         '--sentryPort', String(self.sentry.address().port)
     ];
 
-    self.opts.torchIndex = self.spawnHyperbahnProc(procOpts);
+    spawnTheWorker();
+
+    function spawnTheWorker() {
+        self.opts.torchIndex = self.spawnHyperbahnProc(procOpts);
+    }
 };
 
 HyperbahnBenchmarkRunner.prototype.spawnHyperbahnProc =

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -85,6 +85,13 @@ function spawnRelayServer() {
         '--sentryPort', String(self.sentry.address().port)
     ];
 
+    self.spawnHyperbahnProc(procOpts);
+};
+
+HyperbahnBenchmarkRunner.prototype.spawnHyperbahnProc =
+function spawnHyperbahnProc(procOpts) {
+    var self = this;
+
     var hyperbahnProc = self.run(bahn, procOpts);
     self.relayProcs.push(hyperbahnProc);
     hyperbahnProc.stdout.pipe(process.stderr);

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -44,6 +44,8 @@ function HyperbahnBenchmarkRunner(opts) {
     var self = this;
     BenchmarkRunner.call(self, opts);
 
+    self.startClientDelay = 500;
+
     self.ports.relayServerPort = RELAY_SERVER_PORT;
 }
 util.inherits(HyperbahnBenchmarkRunner, BenchmarkRunner);

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -85,7 +85,7 @@ function spawnRelayServer() {
         '--sentryPort', String(self.sentry.address().port)
     ];
 
-    self.spawnHyperbahnProc(procOpts);
+    self.opts.torchIndex = self.spawnHyperbahnProc(procOpts);
 };
 
 HyperbahnBenchmarkRunner.prototype.spawnHyperbahnProc =


### PR DESCRIPTION
This is the WIP for advertise benchmark. The first step
was to get multiple hyperbahn workers in the benchmark
so we can test ringpop / ad / relay-ad etc.

A secondary step would be to update the bench_client
in tchannel-node to send "ad" messages.