### PR TITLE
test-cluster now works with thrift

### DIFF
--- a/test/forward/thrift.js
+++ b/test/forward/thrift.js
@@ -59,7 +59,7 @@ allocCluster.test('register and forward with thrift', {
 
     echoServerRemote.thriftServer.register(
         echoServerRemote.serverChannel, 'echo::thrift_echo', {}, echo
-    )
+    );
 
     function echo(ctx, req, arg2, arg3, cb) {
         cb(null, {
@@ -78,13 +78,13 @@ allocCluster.test('register and forward with thrift', {
     }, onForwarded);
 
     echoServerRemote.thriftClient.request({
-        serviceName: 'echoRemote',
+        serviceName: 'echoRemote'
     }).send('echo::thrift_echo', null, {
         foo: {
             bar: 2,
             baz: 'hi'
         }
-    }, onForwarded)
+    }, onForwarded);
 
     function onForwarded(err, res) {
         assert.ifError(err);

--- a/test/forward/thrift.js
+++ b/test/forward/thrift.js
@@ -31,7 +31,7 @@ var allocCluster = require('../lib/test-cluster.js');
 allocCluster.test('register and forward with thrift', {
     size: 5,
     namedRemotes: ['echoRemote'],
-    remoteSpecs: {
+    remotes: {
         echoRemote: {
             thriftSpec: path.join(__dirname, 'someSpec.thrift')
         }

--- a/test/forward/thrift.js
+++ b/test/forward/thrift.js
@@ -32,7 +32,9 @@ allocCluster.test('register and forward with thrift', {
     size: 5,
     namedRemotes: ['echoRemote'],
     remoteSpecs: {
-        echoRemote: path.join(__dirname, 'someSpec.thrift')
+        echoRemote: {
+            thriftSpec: path.join(__dirname, 'someSpec.thrift')
+        }
     }
 }, function t(cluster, assert) {
     var TChannelAsThrift = cluster.dummies[0].TChannelAsThrift;
@@ -55,7 +57,7 @@ allocCluster.test('register and forward with thrift', {
         steve.serverChannel, 'echo::thrift_echo', {}, echo
     );
 
-    echoServerRemote.thriftServerChannel.register(
+    echoServerRemote.thriftServer.register(
         echoServerRemote.serverChannel, 'echo::thrift_echo', {}, echo
     )
 
@@ -75,7 +77,7 @@ allocCluster.test('register and forward with thrift', {
         }
     }, onForwarded);
 
-    echoServerRemote.thriftClientChannel.request({
+    echoServerRemote.thriftClient.request({
         serviceName: 'echoRemote',
     }).send('echo::thrift_echo', null, {
         foo: {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -83,6 +83,7 @@ TestCluster.test = tapeCluster(tape, TestCluster);
 
 module.exports = TestCluster;
 
+ /*eslint complexity: 13*/
 function TestCluster(opts) {
     if (!(this instanceof TestCluster)) {
         return new TestCluster(opts);
@@ -241,7 +242,6 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
     channel.listen(0, '127.0.0.1');
     var serviceSpec = self.remoteSpecs[opts.serviceName];
 
-
     if (serviceSpec) {
         thriftSpec = self.remoteSpecs[opts.serviceName].thriftSpec;
     }
@@ -262,7 +262,7 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
 
     serverChannel = channel.makeSubChannel({
         serviceName: opts.serviceName
-    })
+    });
 
     clientChannel = channel.makeSubChannel({
         serviceName: 'autobahn-client',
@@ -274,21 +274,21 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
                 cn: opts.serviceName
             }
         }
-    })
+    });
 
-    if (thriftSpec){
+    if (thriftSpec) {
         var thriftPath = thriftSpec;
         var thriftSource = fs.readFileSync(thriftPath).toString();
 
         thriftServer = channel.TChannelAsThrift({
             source: thriftSource,
             channel: serverChannel
-        })
+        });
 
         thriftClient = channel.TChannelAsThrift({
             source: thriftSource,
             channel: clientChannel
-        })
+        });
     } else {
         serverChannel.register('echo', echo);
     }

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -96,7 +96,7 @@ function TestCluster(opts) {
     self.size = self.opts.size || 2;
     self.dummySize = self.opts.dummySize || 2;
     self.namedRemotesConfig = self.opts.namedRemotes || [];
-    self.remoteSpecs = self.opts.remoteSpecs || {};
+    self.remotesConfig = self.opts.remotes || {};
 
     var defaultKValue = self.size <= 20 ?
         Math.floor(self.size / 2) : 10;
@@ -211,7 +211,7 @@ TestCluster.prototype.bootstrap = function bootstrap(cb) {
             var serviceName = self.namedRemotesConfig[i];
             self.namedRemotes[i] = self.createRemote({
                 serviceName: serviceName,
-                remoteSpecs: self.remoteSpecs[serviceName],
+                remotesConfig: self.remotesConfig[serviceName],
                 trace: self.opts.trace,
                 traceSample: 1
             }, remotesDone.signal);
@@ -240,10 +240,10 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
     self.timers = channel.timers;
     channel.on('listening', onListen);
     channel.listen(0, '127.0.0.1');
-    var serviceSpec = self.remoteSpecs[opts.serviceName];
+    var serviceConfig = self.remotesConfig[opts.serviceName];
 
-    if (serviceSpec) {
-        thriftSpec = self.remoteSpecs[opts.serviceName].thriftSpec;
+    if (serviceConfig) {
+        thriftSpec = serviceConfig.thriftSpec;
     }
 
     if (opts.trace) {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -227,8 +227,9 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
     var self = this;
     var serverChannel;
     var clientChannel;
-    var thriftServerChannel;
-    var thriftClientChannel;
+    var thriftServer;
+    var thriftClient;
+    var thriftSpec;
 
     var channel = TChannel({
         logger: self.logger,
@@ -238,8 +239,12 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
     self.timers = channel.timers;
     channel.on('listening', onListen);
     channel.listen(0, '127.0.0.1');
-    var thriftSpec = self.remoteSpecs[opts.serviceName];
-    var hyperbahnClient;
+    var serviceSpec = self.remoteSpecs[opts.serviceName];
+
+
+    if (serviceSpec) {
+        thriftSpec = self.remoteSpecs[opts.serviceName].thriftSpec;
+    }
 
     if (opts.trace) {
         var tcreporter = TCReporter({
@@ -275,12 +280,12 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
         var thriftPath = thriftSpec;
         var thriftSource = fs.readFileSync(thriftPath).toString();
 
-        thriftServerChannel = channel.TChannelAsThrift({
+        thriftServer = channel.TChannelAsThrift({
             source: thriftSource,
             channel: serverChannel
         })
 
-        thriftClientChannel = channel.TChannelAsThrift({
+        thriftClient = channel.TChannelAsThrift({
             source: thriftSource,
             channel: clientChannel
         })
@@ -295,8 +300,8 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
         serviceName: opts.serviceName,
         hostPort: null,
         destroy: destroy,
-        thriftServerChannel: thriftServerChannel,
-        thriftClientChannel: thriftClientChannel
+        thriftServer: thriftServer,
+        thriftClient: thriftClient
     };
 
     return remote;


### PR DESCRIPTION
If you pass in a thrift file associated with your named remote you can now register with an "as thrift" sub-channel. 

Fun fact: the api is weird so I dont break back-compat.