### PR TITLE
test-cluster: Use logger.error() instead for better debugger

### DIFF
--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -331,7 +331,10 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
 
     function onRegister(err) {
         if (err) {
-            return self.emit('error', err);
+            self.logger.error('Failed to register to hyperbahn for remote', {
+                error: err
+            });
+            return;
         }
 
         cb();


### PR DESCRIPTION
Emitting an error prints a frustratingly useless stack. Logger.error()
does the right thing (TM)

r: @jcorbin @rf @kriskowal