### PR TITLE
Peer reaper don't block

### DIFF
--- a/scripts/verify_included.sh
+++ b/scripts/verify_included.sh
@@ -1,34 +1,16 @@
 #!/usr/bin/env bash
 set -e
-# set -x
 
-# Detect which `ls` flavor is in use
-if ls --color > /dev/null 2>&1; then
-    COLORFLAG="--color=never"
-else
-    COLORFLAG=""
-fi
-
-FILES=$(
-    ls $COLORFLAG test/**/*.js test/*.js | \
-    sed "s/test\//.\//g" | \
-    grep -v 'lib' | \
-    grep -v 'constant-low-volume' | \
-    grep -v './index.js'
-)
-
-# echo $FILES
-
-for FILE in $FILES; do
-    # echo $FILE
-
-    set +e
-    WORD=$(git grep "require.*$FILE" | grep 'test/index')
-    EXIT_CODE="$?"
-    set -e
-
-    if [ "$EXIT_CODE" != "0" ]; then
-        echo "Could not find $FILE";
+find test \
+    -name '*.js' \
+    -not -path 'test/lib/*' \
+    -not -path 'test/time-series/constant-low-volume*' \
+    -not -path 'test/todo.js' \
+    -not -path 'test/index.js' \
+    -not -path 'test/reap-time.js' |
+while read FILE; do
+    if ! git grep -l "require.*\./${FILE#*/}" | grep -q 'test/index' ; then
+        echo "Could not find $FILE" >&2
         exit 1
     fi
 done

--- a/test/forward/dead-remote-reaped.js
+++ b/test/forward/dead-remote-reaped.js
@@ -74,12 +74,26 @@ allocCluster.test('dead exit peers get reaped', {
             return;
         }
 
+        var todo = cluster.apps.length;
+
         // Reap peers
         for (i = 0; i < cluster.apps.length; i++) {
             app = cluster.apps[i];
             serviceProxy = app.clients.serviceProxy;
-            serviceProxy.reapPeers();
+            serviceProxy.reapPeers(doneReapPeers);
         }
+
+        function doneReapPeers() {
+            todo--;
+            if (todo <= 0) {
+                assert.ok(todo === 0);
+
+                afterReapPeers();
+            }
+        }
+    }
+
+    function afterReapPeers() {
 
         // Some of the peers remain
         for (i = 0; i < activeNum; i++) {

--- a/test/lib/collapsed-assert.js
+++ b/test/lib/collapsed-assert.js
@@ -36,6 +36,16 @@ function CollapsedAssert() {
     self._failed = false;
 }
 
+CollapsedAssert.prototype.ifError = function ifError(err, msg, extra) {
+    var self = this;
+
+    if (err) {
+        self._failed = true;
+    }
+
+    self._commands.push(['ifError', err, msg, extra]);
+};
+
 CollapsedAssert.prototype.equal = function equal(a, b, msg, extra) {
     var self = this;
 

--- a/test/reap-time.js
+++ b/test/reap-time.js
@@ -20,10 +20,10 @@
 
 'use strict';
 
-var setTimeout = require('timers').setTimeout;
+/* global console */
+/* eslint-disable no-console */
 
 var allocCluster = require('./lib/test-cluster.js');
-var parallel = require('run-parallel');
 var CollapsedAssert = require('./lib/collapsed-assert');
 
 var NUM_REMOTES = 5000;
@@ -70,7 +70,7 @@ allocCluster.test('make sure peer reaper doesnt take too long', {
     var apiExitNode = cluster.getExitNodes('api')[0];
 
     function doneCreating() {
-        console.log("# done creating remotes");
+        console.log('# done creating remotes');
         cassert.report(assert, 'remote creation successful');
 
         apiExitNode.clients.serviceProxy.reapPeers(doneFirstReapPeers);
@@ -83,7 +83,7 @@ allocCluster.test('make sure peer reaper doesnt take too long', {
         apiExitNode.clients.serviceProxy.reapPeers(doneSecondReapPeers);
 
         var time = Date.now() - start;
-        console.log("# after reap peers", time);
+        console.log('# after reap peers', time);
 
         assert.ok(time < 10, 'reap peers stalls proc for less than 10ms');
     }
@@ -96,7 +96,7 @@ allocCluster.test('make sure peer reaper doesnt take too long', {
         for (i = 0; i < remotes.length; i++) {
             remotes[i].destroy();
         }
-        console.log("done destroying remotes");
+        console.log('# done destroying remotes');
         assert.end();
     }
 });

--- a/test/reap-time.js
+++ b/test/reap-time.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var setTimeout = require('timers').setTimeout;
+
+var allocCluster = require('./lib/test-cluster.js');
+var parallel = require('run-parallel');
+var CollapsedAssert = require('./lib/collapsed-assert');
+
+var NUM_REMOTES = 5000;
+var BATCH_SIZE = 100;
+
+allocCluster.test('make sure peer reaper doesnt take too long', {
+    size: 10,
+    kValue: 1,
+    whitelist: [
+        ['info', 'not setting peer reap timer'],
+        ['warn', 'stale tombstone']
+    ]
+}, function t(cluster, assert) {
+    var i;
+    var batch = 1;
+    var todo = NUM_REMOTES + 1;
+    var remotes = [];
+    var cassert = CollapsedAssert();
+
+    remoteDone(null);
+
+    function remoteDone(err) {
+        cassert.ifError(err);
+
+        todo--;
+        batch--;
+
+        if (todo <= 0) {
+            doneCreating();
+            return;
+        }
+
+        if (batch <= 0) {
+            console.log("# finished batch");
+            batch = BATCH_SIZE;
+            for (i = 0; i < BATCH_SIZE; i++) {
+                remotes.push(cluster.createRemote({
+                    serviceName: 'api',
+                    trace: false
+                }, remoteDone));
+            }
+        }
+    }
+
+    function doneCreating() {
+        console.log("# done creating remotes");
+        cassert.report(assert, 'remote creation successful');
+
+        var apiExitNode = cluster.getExitNodes('api')[0];
+        var start = Date.now();
+        apiExitNode.clients.serviceProxy.reapPeers();
+        apiExitNode.clients.serviceProxy.reapPeers();
+        var end = Date.now();
+        console.log("# done reaping peers", end - start);
+
+        finish();
+    }
+
+    function finish() {
+        for (i = 0; i < remotes.length; i++) {
+            remotes[i].destroy();
+        }
+        assert.end();
+    }
+});


### PR DESCRIPTION
@Raynos 

Amortize peer reaper across event loop ticks. Currently the test doesn't exit, which I expect is an interaction between the peer reaper and the sanity sweep.

NB: adding a check to make sure we don't try to sanity sweep after destroying seems to have fixed the test not ending.