### PR TITLE
Improve peer indexing

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -486,6 +486,13 @@ function addPeerIndex(serviceName, hostPort) {
     addIndexEntry(self.knownPeers, hostPort, serviceName, true);
 };
 
+ServiceDispatchHandler.prototype.deletePeerIndex =
+function deletePeerIndex(serviceName, hostPort) {
+    var self = this;
+
+    deleteIndexEntry(self.knownPeers, hostPort, serviceName);
+};
+
 ServiceDispatchHandler.prototype.computePartialRange =
 function computePartialRange(serviceName, hostPort) {
     var self = this;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -465,8 +465,8 @@ function refreshServicePeer(serviceName, hostPort) {
     }
 
     // The old way: fully connect every egress to all affine peers.
-    peer.connectTo();
     self.addPeerIndex(serviceName, hostPort);
+    peer.connectTo();
 };
 
 ServiceDispatchHandler.prototype.addPeerIndex =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -481,7 +481,7 @@ function addPeerIndex(serviceName, hostPort) {
     var self = this;
 
     // Unmark recently seen peers, so they don't get reaped
-    delete self.peersToReap[hostPort];
+    deleteIndexEntry(self.peersToReap, hostPort, serviceName);
     // Mark known peers, so they are candidates for future reaping
     addIndexEntry(self.knownPeers, hostPort, serviceName, true);
 };

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -563,6 +563,8 @@ function refreshServicePeerPartially(serviceName, hostPort) {
 
     // TODO Drop peers that no longer have affinity for this service, such
     // that they may be elligible for having their connections reaped.
+
+    self.addPeerIndex(serviceName, hostPort);
 };
 
 ServiceDispatchHandler.prototype.connectToServiceWorkers =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -559,12 +559,12 @@ function refreshServicePeerPartially(serviceName, hostPort) {
         partialRange: range
     }));
 
+    self.addPeerIndex(serviceName, hostPort);
+
     self.connectToServiceWorkers(serviceName, range.workers, range.start, range.stop);
 
     // TODO Drop peers that no longer have affinity for this service, such
     // that they may be elligible for having their connections reaped.
-
-    self.addPeerIndex(serviceName, hostPort);
 };
 
 ServiceDispatchHandler.prototype.connectToServiceWorkers =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1149,3 +1149,31 @@ function extendLogInfo(info) {
 // node though
 
 module.exports = ServiceDispatchHandler;
+
+function addIndexEntry(index, keya, keyb, value) {
+    var level = index[keya];
+    if (!level) {
+        level = Object.create(null);
+        index[keya] = level;
+    }
+    level[keyb] = value;
+}
+
+function deleteIndexEntry(index, keya, keyb) {
+    var level = index[keya];
+    if (level && level[keyb]) {
+        delete level[keyb];
+        if (isObjectEmpty(level)) {
+            delete index[keya];
+        }
+    }
+}
+
+/* eslint-disable guard-for-in, no-unused-vars */
+function isObjectEmpty(obj) {
+    for (var prop in obj) {
+        return false;
+    }
+    return true;
+}
+/* eslint-enable guard-for-in, no-unused-vars */

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -948,6 +948,7 @@ function reapSinglePeer(hostPort) {
             return;
         }
         svcchan.peers.delete(hostPort);
+        self.deletePeerIndex(serviceName, hostPort);
     }
 
     self.channel.peers.delete(hostPort);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -483,10 +483,7 @@ function addPeerIndex(serviceName, hostPort) {
     // Unmark recently seen peers, so they don't get reaped
     delete self.peersToReap[hostPort];
     // Mark known peers, so they are candidates for future reaping
-    if (!self.knownPeers[hostPort]) {
-        self.knownPeers[hostPort] = Object.create(null);
-    }
-    self.knownPeers[hostPort][serviceName] = true;
+    addIndexEntry(self.knownPeers, hostPort, serviceName, true);
 };
 
 ServiceDispatchHandler.prototype.computePartialRange =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -454,7 +454,6 @@ function refreshServicePeer(serviceName, hostPort) {
     }
 
     var now = self.channel.timers.now();
-    var peer = self.getServicePeer(serviceName, hostPort);
 
     // Reset the expiration time for this service peer
     self.exitServices[serviceName] = now;
@@ -466,6 +465,7 @@ function refreshServicePeer(serviceName, hostPort) {
 
     // The old way: fully connect every egress to all affine peers.
     self.addPeerIndex(serviceName, hostPort);
+    var peer = self.getServicePeer(serviceName, hostPort);
     peer.connectTo();
 };
 
@@ -560,7 +560,7 @@ function refreshServicePeerPartially(serviceName, hostPort) {
     }));
 
     self.addPeerIndex(serviceName, hostPort);
-
+    self.getServicePeer(serviceName, hostPort);
     self.connectToServiceWorkers(serviceName, range.workers, range.start, range.stop);
 
     // TODO Drop peers that no longer have affinity for this service, such

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -454,13 +454,6 @@ function refreshServicePeer(serviceName, hostPort) {
     }
 
     var now = self.channel.timers.now();
-
-    // Create a peer for the worker.
-    // This is necessary for populating the worker pool regardless of whether
-    // we connect.
-    // TODO This belies an underlying assumption that the peer pool includes
-    // exactly and only the worker pool, that we would eventually reap peers
-    // that have not advertised recently.
     var peer = self.getServicePeer(serviceName, hostPort);
 
     // Reset the expiration time for this service peer

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -473,6 +473,12 @@ function refreshServicePeer(serviceName, hostPort) {
 
     // The old way: fully connect every egress to all affine peers.
     peer.connectTo();
+    self.addPeerIndex(serviceName, hostPort);
+};
+
+ServiceDispatchHandler.prototype.addPeerIndex =
+function addPeerIndex(serviceName, hostPort) {
+    var self = this;
 
     // Unmark recently seen peers, so they don't get reaped
     delete self.peersToReap[hostPort];


### PR DESCRIPTION
This sets the stage to add more indices towards #66:
- factor out general `{add,delete}IndexEntry` utilities
- factor out `{add,delete}PeerIndex` methods
- delete index entries in `reapSinglePeer` to protect against double reap edge cases

r @kriskowal @Raynos 