### PR TITLE
Improve and correct peer drain

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ var ApplicationClients = require('./clients/');
 var ExitNode = require('./exit');
 var EntryNode = require('./entry');
 
+// our call SLA is 30 seconds currently
 var DRAIN_DEADLINE_TIMEOUT = 30 * 1000;
 
 var ApplicationClientsFailureError = WrappedError({

--- a/app.js
+++ b/app.js
@@ -32,9 +32,6 @@ var ApplicationClients = require('./clients/');
 var ExitNode = require('./exit');
 var EntryNode = require('./entry');
 
-// our call SLA is 30 seconds currently
-var DRAIN_DEADLINE_TIMEOUT = 30 * 1000;
-
 var ApplicationClientsFailureError = WrappedError({
     type: 'autobahn.app-clients-failed',
     message: 'Application createClients failed: {origMessage}'
@@ -182,7 +179,8 @@ function startDrain() {
     self.logger.info('got SIGTERM, draining application', self.extendLogInfo({}));
     self.tchannel.drain('shutting down due to SIGTERM', drainedThenClose);
     self.drainDeadlineTimer = self.tchannel.timers.setTimeout(
-        deadlineTimedOut, DRAIN_DEADLINE_TIMEOUT);
+        deadlineTimedOut,
+        self.clients.serviceProxy.drainTimeout);
 
     function drainedThenClose() {
         self.drainedThenClose();

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -939,8 +939,8 @@ function reapSinglePeer(hostPort) {
     }
 
     var serviceNames = Object.keys(self.peersToReap[hostPort]);
-    for (var j = 0; j < serviceNames.length; j++) {
-        var serviceName = serviceNames[j];
+    for (var i = 0; i < serviceNames.length; i++) {
+        var serviceName = serviceNames[i];
         var svcchan = self.getServiceChannel(serviceName);
         if (!svcchan) {
             return;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -41,6 +41,7 @@ var DEFAULT_MIN_PEERS_PER_WORKER = 5;
 var DEFAULT_MIN_PEERS_PER_RELAY = 5;
 var DEFAULT_STATS_PERIOD = 30 * 1000; // every 30 seconds
 var DEFAULT_REAP_PEERS_PERIOD = 0; // never
+var DEFAULT_DRAIN_TIMEOUT = 30;
 
 var RATE_LIMIT_TOTAL = 'total';
 var RATE_LIMIT_SERVICE = 'service';
@@ -89,6 +90,7 @@ function ServiceDispatchHandler(options) {
     self.partialAffinityEnabled = options.partialAffinityEnabled;
     self.minPeersPerWorker = options.minPeersPerWorker || DEFAULT_MIN_PEERS_PER_WORKER;
     self.minPeersPerRelay = options.minPeersPerRelay || DEFAULT_MIN_PEERS_PER_RELAY;
+    self.drainTimeout = options.drainTimeout || DEFAULT_DRAIN_TIMEOUT;
 
     self.periodicStatsTimer = null;
     self.statsPeriod = options.statsPeriod || DEFAULT_STATS_PERIOD;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -41,7 +41,10 @@ var DEFAULT_MIN_PEERS_PER_WORKER = 5;
 var DEFAULT_MIN_PEERS_PER_RELAY = 5;
 var DEFAULT_STATS_PERIOD = 30 * 1000; // every 30 seconds
 var DEFAULT_REAP_PEERS_PERIOD = 0; // never
-var DEFAULT_DRAIN_TIMEOUT = 30;
+
+// our call SLA is 30 seconds currently
+// TODO: dedupe with DRAIN_DEADLINE_TIMEOUT from app.js
+var DEFAULT_DRAIN_TIMEOUT = 30 * 1000;
 
 var RATE_LIMIT_TOTAL = 'total';
 var RATE_LIMIT_SERVICE = 'service';

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -881,7 +881,11 @@ function requestReapPeers() {
 ServiceDispatchHandler.prototype.reapPeers =
 function reapPeers(callback) {
     var self = this;
-    self.reapPeersTimer = null;
+
+    if (self.reapPeersTimer) {
+        self.channel.timers.clearTimeout(self.reapPeersTimer);
+        self.reapPeersTimer = null;
+    }
 
     var peersToReap = Object.keys(self.peersToReap);
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -43,7 +43,6 @@ var DEFAULT_STATS_PERIOD = 30 * 1000; // every 30 seconds
 var DEFAULT_REAP_PEERS_PERIOD = 0; // never
 
 // our call SLA is 30 seconds currently
-// TODO: dedupe with DRAIN_DEADLINE_TIMEOUT from app.js
 var DEFAULT_DRAIN_TIMEOUT = 30 * 1000;
 
 var RATE_LIMIT_TOTAL = 'total';


### PR DESCRIPTION
- clear any prior timer (just in case)
- use `peer.drain` with a timeout
- actually close drained connections
- don't delete the peer until after the drain and close is done

r @Raynos @rf 