### PR TITLE
Improve partial range

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -567,6 +567,8 @@ function refreshServicePeerPartially(serviceName, hostPort) {
         return;
     }
 
+    var affineWorkers = self.getAffineWorkers(serviceName, range);
+
     self.logger.info('Refreshing service peer affinity', self.extendLogInfo({
         serviceName: serviceName,
         serviceHostPort: hostPort,
@@ -575,22 +577,16 @@ function refreshServicePeerPartially(serviceName, hostPort) {
 
     self.addPeerIndex(serviceName, hostPort);
     self._getServicePeer(chan, hostPort);
-    self.connectToServiceWorkers(serviceName, range);
 
-    // TODO Drop peers that no longer have affinity for this service, such
-    // that they may be elligible for having their connections reaped.
-};
-
-ServiceDispatchHandler.prototype.connectToServiceWorkers =
-function connectToServiceWorkers(serviceName, range) {
-    var self = this;
-    var affineWorkers = self.getAffineWorkers(serviceName, range);
     for (var i = 0; i < affineWorkers.length; i++) {
-        var peer = self.getServicePeer(serviceName, affineWorkers[i]);
+        peer = self._getServicePeer(chan, affineWorkers[i]);
         if (!peer.isConnected('out')) {
             peer.connectTo();
         }
     }
+
+    // TODO Drop peers that no longer have affinity for this service, such
+    // that they may be elligible for having their connections reaped.
 };
 
 ServiceDispatchHandler.prototype.getAffineWorkers =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -568,6 +568,13 @@ function refreshServicePeerPartially(serviceName, hostPort) {
     }
 
     var affineWorkers = self.getAffineWorkers(serviceName, range);
+    if (!affineWorkers.length) {
+        self.logger.error('empty affineWorkers, this should not happen', self.extendLogInfo({
+            serviceName: serviceName,
+            advertisingPeer: hostPort,
+            partialRange: range
+        }));
+    }
 
     self.logger.info('Refreshing service peer affinity', self.extendLogInfo({
         serviceName: serviceName,

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -546,6 +546,10 @@ ServiceDispatchHandler.prototype.refreshServicePeerPartially =
 function refreshServicePeerPartially(serviceName, hostPort) {
     var self = this;
 
+    // guaranteed non-null by refreshServicePeer above; we call this only so
+    // as not to pass another arg along to the partial path.
+    var chan = self.getServiceChannel(serviceName, false);
+
     var range = self.computePartialRange(serviceName, hostPort);
     if (range.length < 0) {
         self.logger.warn('Relay could not find itself in the affinity set for service', self.extendLogInfo({
@@ -564,7 +568,7 @@ function refreshServicePeerPartially(serviceName, hostPort) {
     }));
 
     self.addPeerIndex(serviceName, hostPort);
-    self.getServicePeer(serviceName, hostPort);
+    self._getServicePeer(chan, hostPort);
     self.connectToServiceWorkers(serviceName, range.workers, range.start, range.stop);
 
     // TODO Drop peers that no longer have affinity for this service, such

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -494,10 +494,11 @@ ServiceDispatchHandler.prototype.computePartialRange =
 function computePartialRange(serviceName, hostPort) {
     var self = this;
 
+    var serviceChannel = self.getOrCreateServiceChannel(serviceName);
+
     // Obtain and sort the affine worker and relay lists.
     var relays = Object.keys(self.egressNodes.exitsFor(serviceName));
     relays.sort();
-    var serviceChannel = self.getOrCreateServiceChannel(serviceName);
     var workers = serviceChannel.peers.keys();
     workers.sort();
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -550,6 +550,12 @@ function refreshServicePeerPartially(serviceName, hostPort) {
     // as not to pass another arg along to the partial path.
     var chan = self.getServiceChannel(serviceName, false);
 
+    var peer = chan.peers.get(hostPort);
+
+    if (!peer) {
+        peer = self._getServicePeer(chan, hostPort);
+    }
+
     var range = self.computePartialRange(serviceName, hostPort);
     if (range.length < 0) {
         self.logger.warn('Relay could not find itself in the affinity set for service', self.extendLogInfo({


### PR DESCRIPTION
- `#computePartialRange` now works completely in its "scratch space" object, which it returns for maximum debug transparency
- `#computePartialRange` took over the interval shenanigans that `#connecToServiceWorkers` used to have to
- connection logic is now inline in `#refreshServicePeerPartially` preparing for future work out of #66 
- explicit check and error log for pathological case

r @kriskowal @Raynos 