### PR TITLE
Affinity change vs refresh

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -472,9 +472,7 @@ function refreshServicePeer(serviceName, hostPort) {
     // The old way: fully connect every egress to all affine peers.
     self.addPeerIndex(serviceName, hostPort);
     var peer = self.getServicePeer(serviceName, hostPort);
-    if (!peer.isConnected('out')) {
-        peer.connectTo();
-    }
+    self.ensurePeerConnected(peer, 'service peer refresh');
 };
 
 ServiceDispatchHandler.prototype.addPeerIndex =
@@ -492,6 +490,15 @@ function deletePeerIndex(serviceName, hostPort) {
     var self = this;
 
     deleteIndexEntry(self.knownPeers, hostPort, serviceName);
+};
+
+ServiceDispatchHandler.prototype.ensurePeerConnected =
+function ensurePeerConnected(peer, reason) {
+    if (peer.isConnected('out')) {
+        return;
+    }
+
+    peer.connectTo();
 };
 
 ServiceDispatchHandler.prototype.computePartialRange =
@@ -600,9 +607,7 @@ function refreshServicePeerPartially(serviceName, hostPort) {
 
     for (var i = 0; i < range.affineWorkers.length; i++) {
         peer = self._getServicePeer(chan, range.affineWorkers[i]);
-        if (!peer.isConnected('out')) {
-            peer.connectTo();
-        }
+        self.ensurePeerConnected(peer, 'service peer affinity refresh');
     }
 
     // TODO Drop peers that no longer have affinity for this service, such

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -596,9 +596,9 @@ function refreshServicePeerPartially(serviceName, hostPort) {
         }));
     }
 
-    self.logger.info('Refreshing service peer affinity', self.extendLogInfo({
+    self.logger.info('implementing affinity change', self.extendLogInfo({
         serviceName: serviceName,
-        serviceHostPort: hostPort,
+        newPeer: hostPort,
         partialRange: range
     }));
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -585,6 +585,7 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
     var chan = self.getServiceChannel(serviceName, false);
 
     var peer = chan.peers.get(hostPort);
+    var connectedPeers = self.connectedServicePeers[serviceName];
 
     if (!peer) {
         peer = self._getServicePeer(chan, hostPort);
@@ -607,7 +608,6 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
             advertisingPeer: hostPort,
             partialRange: range
         }));
-
     }
 
     var toConnect = [];
@@ -617,7 +617,9 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
     for (i = 0; i < range.affineWorkers.length; i++) {
         worker = range.affineWorkers[i];
         isAffine[worker] = true;
-        toConnect.push(worker);
+        if (!connectedPeers || !connectedPeers[worker]) {
+            toConnect.push(worker);
+        }
     }
 
     self.logger.info('implementing affinity change', self.extendLogInfo({

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -594,19 +594,29 @@ function refreshServicePeerPartially(serviceName, hostPort) {
             advertisingPeer: hostPort,
             partialRange: range
         }));
+
+    }
+
+    var toConnect = [];
+    var i;
+    var worker;
+    for (i = 0; i < range.affineWorkers.length; i++) {
+        worker = range.affineWorkers[i];
+        toConnect.push(worker);
     }
 
     self.logger.info('implementing affinity change', self.extendLogInfo({
         serviceName: serviceName,
         newPeer: hostPort,
-        partialRange: range
+        partialRange: range,
+        toConnect: toConnect
     }));
 
     self.addPeerIndex(serviceName, hostPort);
     self._getServicePeer(chan, hostPort);
 
-    for (var i = 0; i < range.affineWorkers.length; i++) {
-        peer = self._getServicePeer(chan, range.affineWorkers[i]);
+    for (i = 0; i < toConnect.length; i++) {
+        peer = self._getServicePeer(chan, toConnect[i]);
         self.ensurePeerConnected(peer, 'service peer affinity refresh');
     }
 


### PR DESCRIPTION
- add new `connectedServicePeers` index
- which lets us do a shorter fast path for refreshing an existing peer
- setting the stage to later to more work in the "something actually changed" path, such as disconnecting from ex-affine peers per the prior TODO

r @Raynos @kriskowal 