### PR TITLE
ServiceDispatchHandler#reapSinglePeer: improve skip check

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -983,7 +983,7 @@ ServiceDispatchHandler.prototype.reapSinglePeer =
 function reapSinglePeer(hostPort) {
     var self = this;
 
-    if (!self.peersToReap[hostPort]) {
+    if (self.knownPeers[hostPort]) {
         return;
     }
 


### PR DESCRIPTION
This change should be currently a noop, but this is closer to the source of truth and allows us to shift the generational rotation semantics.

r @kriskowal 