### PR TITLE
Migrate away from uber-standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "extends": ["perf-standard"],
     "rules": {
         "max-params": [2, 5],
         "max-len": [0],

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
   },
   "devDependencies": {
     "body": "^5.1.0",
+    "eslint": "0.23.0",
+    "eslint-config-perf-standard": "1.0.0",
     "format-stack": "4.1.0",
     "istanbul": "^0.3.17",
     "kafka-logger": "^6.1.0",
@@ -57,8 +59,7 @@
     "sentry-logger": "^3.0.3",
     "tape": "^3.4.0",
     "time-mock": "^0.1.2",
-    "uber-licence": "1.5.1",
-    "uber-standard": "3.6.5"
+    "uber-licence": "1.5.1"
   },
   "licenses": [],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "check-cover": "istanbul check-coverage || echo coverage failed",
     "check-ls": "npm ls --loglevel=http --parseable 1>/dev/null && echo '# npm is in a good state'",
     "cover": "npm run check-files && npm run test-cover -s && npm run check-cover -s",
-    "lint": "standard -v --reporter stylish && echo '# linter passed'",
+    "lint": "eslint $(git ls-files | grep '.js$') && echo '# linter passed'",
     "shrinkwrap": "node bin/shrinkwrap.js --dev",
     "travis": "npm run test",
     "test": "npm run check-licence && npm run check-ls -s && npm run lint -s && npm run cover && npm run check-benchmark -s",

--- a/rate_limiter.js
+++ b/rate_limiter.js
@@ -207,7 +207,7 @@ function refresh() {
     }
 
     self.refreshTimer = self.timers.setTimeout(
-        function refresh() {
+        function refreshAgain() {
             self.refresh();
         },
         self.refreshDelay

--- a/test/hyperbahn-client/rate-limiter-lazy.js
+++ b/test/hyperbahn-client/rate-limiter-lazy.js
@@ -95,7 +95,7 @@ function runTests(HyperbahnCluster) {
                 send.bind(null, opts),
                 send.bind(null, opts),
                 function check(done) {
-                    cluster.apps.forEach(function check(app) {
+                    cluster.apps.forEach(function checkApp(app) {
                         var relayChannel = app.clients.tchannel;
                         assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 3, 'total request');
                         assert.equals(relayChannel.handler.rateLimiter.serviceCounters.steve.rps, 3, 'request for steve');

--- a/test/hyperbahn-client/rate-limiter.js
+++ b/test/hyperbahn-client/rate-limiter.js
@@ -94,7 +94,7 @@ function runTests(HyperbahnCluster) {
                 send.bind(null, opts),
                 send.bind(null, opts),
                 function check(done) {
-                    cluster.apps.forEach(function check(app) {
+                    cluster.apps.forEach(function checkApp(app) {
                         var relayChannel = app.clients.tchannel;
                         assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 3, 'total request');
                         assert.equals(relayChannel.handler.rateLimiter.serviceCounters.steve.rps, 3, 'request for steve');

--- a/test/lib/relay-network.js
+++ b/test/lib/relay-network.js
@@ -188,7 +188,7 @@ RelayNetwork.prototype.setCluster = function setCluster(cluster) {
         // In response to artificial advertisement
         self.serviceNames.forEach(function eachServiceName(serviceName, index2) {
             if (egressNodes.isExitFor(serviceName)) {
-                self.serviceChannels[index2].forEach(function each(serviceChannel) {
+                self.serviceChannels[index2].forEach(function eachService(serviceChannel) {
                     relayChannel.handler.getServicePeer(serviceName, serviceChannel.hostPort);
                 });
             }
@@ -198,7 +198,7 @@ RelayNetwork.prototype.setCluster = function setCluster(cluster) {
     // Create and connect service channels
     self.subChannels = [];
     self.subChannelsByName = {};
-    self.serviceChannels.forEach(function each(channels, serviceIndex) {
+    self.serviceChannels.forEach(function eachService(channels, serviceIndex) {
         var serviceName = self.serviceNames[serviceIndex];
         var subChannels = channels.map(function mappy(channel, channelIndex) {
             var subChannel = channel.makeSubChannel({
@@ -228,7 +228,7 @@ RelayNetwork.prototype.forEachSubChannel = function forEachSubChannel(callback) 
     var self = this;
     self.subChannels.forEach(function each(subChannels, serviceIndex) {
         var serviceName = self.serviceNames[serviceIndex];
-        subChannels.forEach(function each(subChannel, instanceIndex) {
+        subChannels.forEach(function eachChannel(subChannel, instanceIndex) {
             callback(subChannel, serviceName, instanceIndex);
         });
     });
@@ -257,7 +257,7 @@ RelayNetwork.prototype.connectServices = function connectServices(callback) {
     var plans = [];
 
     self.relayChannels.forEach(function each(relayChannel, relayIndex) {
-        self.serviceNames.forEach(function each(serviceName) {
+        self.serviceNames.forEach(function eachService(serviceName) {
             if (self.egressNodesForRelay[relayIndex].isExitFor(serviceName)) {
                 plans.push(planToConnect(
                     relayChannel,

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -84,7 +84,7 @@ TestCluster.test = tapeCluster(tape, TestCluster);
 
 module.exports = TestCluster;
 
- /*eslint complexity: 13*/
+/*eslint complexity: [2, 15] */
 function TestCluster(opts) {
     if (!(this instanceof TestCluster)) {
         return new TestCluster(opts);


### PR DESCRIPTION
uber-standard has outlived it's welcome. This PR migrates
us to using eslint directly.

By using eslint directly we can avoid version hell and
have tighter control over the version of eslint. 

I've upgraded from 0.19.0 to 0.23.0 to start using
the "extends" feature.

To avoid the "copy paste" problem I've uploaded our
eslintrc into a seperate package and I'm using the
support eslint has for eslint-config-* packages.

The reason why we are moving away from uber-standard
is that we are two major versions behind and upgrading
to the latest version completely breaks everything.

The uber-standard project has also devolved to be about
writing frontend code and it's better we fork into
a new set of eslint rules that are aimed at writing
performant javascript.

r: @jcorbin @kriskowal