### PR TITLE
Fix detached publish

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -30,7 +30,12 @@ fi
 
 npm version "$1"
 
-git push origin master --tags
+if head_ref=$(git symbolic-ref HEAD 2>/dev/null); then
+    branch_name=${head_ref##*/}
+    git push origin "$branch_name" --tags
+else
+    git push origin --tags
+fi
 
 git archive --prefix=package/ --format tgz master >package.tgz
 ${NPM:-npm} publish --registry=https://registry.npmjs.org/ package.tgz --tag "${NPM_TAG:-alpha}"

--- a/publish.sh
+++ b/publish.sh
@@ -37,7 +37,7 @@ else
     git push origin --tags
 fi
 
-git archive --prefix=package/ --format tgz master >package.tgz
+git archive --prefix=package/ --format tgz HEAD >package.tgz
 ${NPM:-npm} publish --registry=https://registry.npmjs.org/ package.tgz --tag "${NPM_TAG:-alpha}"
 rm package.tgz
 npm cache clean hyperbahn


### PR DESCRIPTION
This makes it easier to do a "detached" publish, like so:

```sh
$ git checkout v2.13.13
HEAD is now at 7695f10... 2.13.13

$ git cherry-pick -m1 master
[detached HEAD 2e7f285] Merge pull request #123 from uber/fix_bug
 Author: Joshua T Corbin <jcorbin@wunjo.org>
 Date: Thu Nov 5 10:59:30 2015 -0800
 1 file changed, 11 insertions(+), 1 deletion(-)

$ ./publish.sh patch
XXX this used to not work
```

Before this change, the `publish.sh patch` would blindly prepare and try to publish a package from the master branch, not the detached HEAD; now it will do so going forward.

r @Raynos @rf 