### PR TITLE
test: Remove flap by improving assert

### DIFF
--- a/test/forward/forwarding-to-down-server.js
+++ b/test/forward/forwarding-to-down-server.js
@@ -86,6 +86,7 @@ allocCluster.test('forwarding to a down service', {
         for (var i = 0; i < logLines.length; i++) {
             var logLine = logLines[i];
             var logErr = logLine.meta.error;
+            var logMeta = logLine.meta;
             if (logLine.msg === 'forwarding error frame') {
                 cassert.equal(logLine.meta.isErrorFrame, true,
                     'expected error frame');
@@ -103,7 +104,8 @@ allocCluster.test('forwarding to a down service', {
 
                 var expectedAddr =
                     logErr.socketRemoteAddr === steve.hostPort ||
-                    logErr.outRequestAddr === steve.hostPort;
+                    logErr.outRequestAddr === steve.hostPort ||
+                    logMeta.remoteName === steve.hostPort;
                 // if (!expectedAddr) console.error('WRU', steve.hostPort, logErr);
                 cassert.ok(expectedAddr, 'expected exception to steve');
 


### PR DESCRIPTION
This was flapping because non-deterministic log statement.
I added another case to catch the connection error
shape.

Observation: We could use an `extendLogInfo()` like
consistency for fields on error instance or stop asserting
on error fields and continue asserting on meta fields.

r: @jcorbin @rf