### PR TITLE
Finally use real stats in the rate limiter

### DIFF
--- a/rate_limiter.js
+++ b/rate_limiter.js
@@ -127,7 +127,7 @@ function refreshCounter(counter, rpsStatsName, rpsLimitStatsName, createStatsTag
         if (rpsStatsName && counter.rps) {
             self.batchStats.pushStat(
                 rpsStatsName,
-                'counter',
+                'timing',
                 counter.rps,
                 statsTag
             );

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -284,7 +284,7 @@ function handleLazily(conn, reqFrame) {
                     serviceCounters: self.rateLimiter.serviceCounters,
                     edgeCounters: self.rateLimiter.edgeCounters
                 })));
-            conn.sendLazyErrorFrameForReq(reqFrame, 'Busy', serviceName + ' is rate-limited by the rps of ' + serviceLimit);
+            conn.sendLazyErrorFrameForReq(reqFrame, 'Busy', serviceName + ' is rate-limited by the service rps of ' + serviceLimit);
             return true;
         }
     }

--- a/test/hyperbahn-client/rate-limiter-lazy.js
+++ b/test/hyperbahn-client/rate-limiter-lazy.js
@@ -243,7 +243,7 @@ function runTests(HyperbahnCluster) {
                         serviceName: steve.serviceName
                     }), 'echo', null, 'hello', function onResponse(err, res) {
                         assert.ok(err && err.type === 'tchannel.busy' &&
-                            err.message === 'steve is rate-limited by the rps of 2',
+                            err.message === 'steve is rate-limited by the service rps of 2',
                             'should be rate limited');
 
                         done();

--- a/test/hyperbahn-client/rate-limiter.js
+++ b/test/hyperbahn-client/rate-limiter.js
@@ -240,7 +240,7 @@ function runTests(HyperbahnCluster) {
                         serviceName: steve.serviceName
                     }), 'echo', null, 'hello', function onResponse(err, res) {
                         assert.ok(err && err.type === 'tchannel.busy' &&
-                            err.message === 'steve is rate-limited by the rps of 2',
+                            err.message === 'steve is rate-limited by the service rps of 2',
                             'should be rate limited');
                         done();
                     });

--- a/test/rate-limiter.js
+++ b/test/rate-limiter.js
@@ -147,77 +147,77 @@ allocCluster.test('rps counter works in 1.5 seconds', {
         });
 
         var expected = [{
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.total-rps',
             value: null,
-            delta: 5,
-            time: null
+            delta: null,
+            time: 5
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.total-rps',
             value: null,
-            delta: 5,
-            time: null
+            delta: null,
+            time: 5
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.service-rps.steve',
             value: null,
-            delta: 3,
-            time: null
+            delta: null,
+            time: 3
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.service-rps.bob',
             value: null,
-            delta: 2,
-            time: null
+            delta: null,
+            time: 2
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.steve',
             value: null,
-            delta: 3,
-            time: null
+            delta: null,
+            time: 3
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.bob',
             value: null,
-            delta: 2,
-            time: null
+            delta: null,
+            time: 2
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.total-rps',
             value: null,
-            delta: 2,
-            time: null
+            delta: null,
+            time: 2
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.total-rps',
             value: null,
-            delta: 2,
-            time: null
+            delta: null,
+            time: 2
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.service-rps.steve',
             value: null,
-            delta: 1,
-            time: null
+            delta: null,
+            time: 1
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.service-rps.bob',
             value: null,
-            delta: 1,
-            time: null
+            delta: null,
+            time: 1
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.steve',
             value: null,
-            delta: 1,
-            time: null
+            delta: null,
+            time: 1
         }, {
-            type: 'c',
+            type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.bob',
             value: null,
-            delta: 1,
-            time: null
+            delta: null,
+            time: 1
         }];
 
         assert.deepEqual(rateLimitStats, expected,


### PR DESCRIPTION
We used to emit counters every second to get a feel
for how hot the rate limiter is.

This is terrible because if we get a huge spike for
0.2s then it gets smoothed out in the 10s aggregation.

Using counter & scaleToSecond() gets us the average
when we really want the max.

By using a timing and rendering the `max` of the timing
in grafana we can get an accurate look at the state
of the rate limiter.

r: @jcorbin @kriskowal