### PR TITLE
ServiceDispatchHandler: deafult the peer reaper on at 5min interval

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -40,7 +40,7 @@ var SERVICE_PURGE_PERIOD = 5 * 60 * 1000;
 var DEFAULT_MIN_PEERS_PER_WORKER = 5;
 var DEFAULT_MIN_PEERS_PER_RELAY = 5;
 var DEFAULT_STATS_PERIOD = 30 * 1000; // every 30 seconds
-var DEFAULT_REAP_PEERS_PERIOD = 0; // never
+var DEFAULT_REAP_PEERS_PERIOD = 5 * 60 * 1000; // every 5 minutes
 
 // our call SLA is 30 seconds currently
 var DEFAULT_DRAIN_TIMEOUT = 30 * 1000;


### PR DESCRIPTION
The peer reaper has proven itself, and accidentally not having it on
significant downside.  Since we've been running it in production at 5min
interval, let's make that the default.

r @raynos @rf