### PR TITLE
Add section-ized log dumping to test/forward/dead-remote-reaped.js

### DIFF
--- a/test/forward/dead-remote-reaped.js
+++ b/test/forward/dead-remote-reaped.js
@@ -227,7 +227,6 @@ function checkAllExitPeers(cluster, assert, isDead) {
         });
         peersInfo.serviceNames = Object.keys(peersInfo.seenServiceName);
 
-        assert.comment('peersInfo: ' + JSON.stringify(peersInfo));
         if (isDead && isDead[i]) {
             assert.equal(
                 peersInfo.serviceNames.length, 0,


### PR DESCRIPTION
Provided much needed log visibility while debugging #66.

r @raynos @rf