### PR TITLE
Improve partial affinity refresh

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -682,6 +682,8 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
 
         if (connected) {
             self.ensurePeerConnected(serviceName, peer, 'service peer affinity refresh', now);
+        } else {
+            self.ensurePeerDisconnected(serviceName, peer, 'service peer affinity refresh', now);
         }
 
         self.logger.info('refreshed peer partially', self.extendLogInfo({

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -592,6 +592,24 @@ function ensurePeerConnected(serviceName, peer, reason, now) {
     peer.connectTo();
 };
 
+ServiceDispatchHandler.prototype.getPartialRange =
+function getPartialRange(serviceName, reason) {
+    var self = this;
+
+    var range = self.computePartialRange(serviceName);
+    if (range.relayIndex < 0) {
+        self.logger.warn('Relay could not find itself in the affinity set for service', self.extendLogInfo({
+            serviceName: serviceName,
+            reason: reason,
+            partialRange: range
+        }));
+        // TODO: upgrade two-in-a-row or more to an error
+        return null;
+    }
+
+    return range;
+};
+
 ServiceDispatchHandler.prototype.computePartialRange =
 function computePartialRange(serviceName) {
     var self = this;
@@ -725,14 +743,8 @@ ServiceDispatchHandler.prototype.ensurePartialConnections =
 function ensurePartialConnections(chan, serviceName, reason, now) {
     var self = this;
 
-    var range = self.computePartialRange(serviceName);
-    if (range.relayIndex < 0) {
-        self.logger.warn('Relay could not find itself in the affinity set for service', self.extendLogInfo({
-            serviceName: serviceName,
-            reason: reason,
-            partialRange: range
-        }));
-        // TODO: upgrade two-in-a-row or more to an error
+    var range = self.getPartialRange(serviceName, reason);
+    if (!range) {
         return null;
     }
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -688,6 +688,7 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
 
         self.logger.info('refreshed peer partially', self.extendLogInfo({
             serviceName: serviceName,
+            connectedPeers: connectedPeers,
             serviceHostPort: hostPort,
             isConnected: connected
         }));


### PR DESCRIPTION
Changes made while debugging #66

- add audit against computed partial range
- call `#ensurePeerDisconnected` for symmetry and more consistency
- a bit more log info

r @Raynos @rf