### PR TITLE
Improve some overly log-sensitive tests

### DIFF
--- a/test/clients/heap-dumps.js
+++ b/test/clients/heap-dumps.js
@@ -36,9 +36,10 @@ allocCluster.test('tchannel heap dumps', function t(cluster, assert) {
         assert.ok(resp.body.path, 'heap dump does not return path');
 
         var logs = cluster.logger.items();
-        assert.equal(logs.length, 1);
-        assert.equal(logs[0].msg, 'write a heapsnapshot');
-        assert.equal(logs[0].meta.file, resp.body.path);
+        assert.ok(logs.some(function findExpected(log) {
+            return log.msg === 'write a heapsnapshot' &&
+                   log.meta.file === resp.body.path;
+        }));
 
         setTimeout(onTimeout, 1000);
 

--- a/test/forward/forwarding-req-defaults.js
+++ b/test/forward/forwarding-req-defaults.js
@@ -48,7 +48,9 @@ allocCluster.test('forwarding small timeout concurrently', {
         assert.ok(err);
         assert.equal(err.message, 'unexpected error');
 
-        var lines = cluster.logger.items();
+        var lines = cluster.logger.items().filter(function only(log) {
+            return log.msg === 'forwarding error frame';
+        });
         assert.ok(lines.length >= 1);
         assert.equal(lines[0].meta.error.type, 'tchannel.unexpected');
 

--- a/test/forward/forwarding-respects-relay-flags.js
+++ b/test/forward/forwarding-respects-relay-flags.js
@@ -62,7 +62,9 @@ allocCluster.test('register and forward', {
 
         assert.equal(counter, 1);
 
-        var logs = cluster.logger.items();
+        var logs = cluster.logger.items().filter(function only(log) {
+            return log.msg === 'forwarding error frame';
+        });
         assert.ok(logs.length >= 1 && logs.length <= 2);
 
         assert.equal(logs[0].levelName, 'warn');

--- a/test/forward/forwarding-to-down-server.js
+++ b/test/forward/forwarding-to-down-server.js
@@ -92,8 +92,9 @@ allocCluster.test('forwarding to a down service', {
                     'expected error frame');
                 cassert.equal(logLine.meta.serviceName, 'steve',
                     'expected steve error');
-            } else if (logLine.msg === 'Refreshing service peer affinity') {
-                cassert.ok(true, 'expected peer affinity refresh');
+            } else if (logLine.msg === 'Refreshing service peer affinity' ||
+                       logLine.msg === 'implementing affinity change') {
+                cassert.ok(true, 'expected partial affinity logs');
             } else if (logLine.msg === 'error while forwarding' ||
                        logLine.msg === 'resetting connection') {
                 if (logLine.msg === 'error while forwarding') {
@@ -121,7 +122,7 @@ allocCluster.test('forwarding to a down service', {
                 }
                 cassert.ok(expectedType, 'Expected exception to be network error');
             } else {
-                cassert.ok(false, 'unexpected log line');
+                cassert.ok(false, 'unexpected log line: ' + logLine.msg);
             }
         }
         cassert.report(assert, 'logs should be correct');

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -142,6 +142,8 @@ function TestCluster(opts) {
             );
         }
     }
+
+    self.logger.whitelist('info', 'implementing affinity change');
 }
 inherits(TestCluster, EventEmitter);
 

--- a/test/register/register-when-exit-node-is-down.js
+++ b/test/register/register-when-exit-node-is-down.js
@@ -73,7 +73,9 @@ allocCluster.test('register when exit node is down', {
         assert.ok(result.body.connectionCount <= 3 &&
             result.body.connectionCount > 0);
 
-        var errors = cluster.logger.items();
+        var errors = cluster.logger.items().filter(function only(log) {
+            return log.msg === 'Relay advertise failed with expected err';
+        });
 
         assert.equal(errors.length, 1);
         assert.equal(errors[0].msg,


### PR DESCRIPTION
Towards #66:

- partial affinity info logs are now a normal part of cluster start up...
- ...so every single user of test cluster provokes them, even while bootstrapping
- so I chose to whitelist it in test cluster directly

I then found:
- the heap test was rather particular about seeing exactly its one log
- we had this forwarding test that also was sad about random new logs

Perhaps we should have the test-cluster go a step further and drop these logs
so that tests don't have to be modified to accommodate them?

r @raynos