### PR TITLE
Cache partial ranges

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -645,13 +645,9 @@ function getPartialRange(serviceName, reason, now) {
     var partialRange = self.partialRanges[serviceName];
     if (!partialRange) {
         var exitNodes = self.egressNodes.exitsFor(serviceName);
-        var relays = Object.keys(exitNodes);
-        relays.sort();
-
         var serviceChannel = self.getOrCreateServiceChannel(serviceName);
-        var workers = serviceChannel.peers.keys();
-        workers.sort();
-
+        var relays = Object.keys(exitNodes).sort();
+        var workers = serviceChannel.peers.keys().sort();
         partialRange = new PartialRange(
             self.channel.hostPort,
             self.minPeersPerWorker,

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -633,7 +633,18 @@ ServiceDispatchHandler.prototype.getPartialRange =
 function getPartialRange(serviceName, reason, now) {
     var self = this;
 
-    var partialRange = self.computePartialRange(serviceName, now);
+    var partialRange = new PartialRange(
+        self.channel.hostPort,
+        self.minPeersPerWorker,
+        self.minPeersPerRelay
+    );
+
+    partialRange.compute(
+        self.getRelaysFor(serviceName),  // Obtain the (cached) sorted affine relay list
+        self.getWorkersFor(serviceName), // Obtain and sort the affine worker list
+        now
+    );
+
     if (!partialRange.isValid()) {
         // This should only occur if an advertisement loses the race with a
         // relay ring membership change.
@@ -648,22 +659,6 @@ function getPartialRange(serviceName, reason, now) {
         return null;
     }
 
-    return partialRange;
-};
-
-ServiceDispatchHandler.prototype.computePartialRange =
-function computePartialRange(serviceName, now) {
-    var self = this;
-    var partialRange = new PartialRange(
-        self.channel.hostPort,
-        self.minPeersPerWorker,
-        self.minPeersPerRelay
-    );
-    partialRange.compute(
-        self.getRelaysFor(serviceName),  // Obtain the (cached) sorted affine relay list
-        self.getWorkersFor(serviceName), // Obtain and sort the affine worker list
-        now
-    );
     return partialRange;
 };
 

--- a/test/lib/test-app.js
+++ b/test/lib/test-app.js
@@ -165,7 +165,11 @@ function checkExitPeers(assert, opts) {
     var expectedConnectedOut = true;
 
     if (self.clients.serviceProxy.partialAffinityEnabled) {
-        var range = self.clients.serviceProxy.computePartialRange(opts.serviceName);
+        var range = self.clients.serviceProxy.getPartialRange(opts.serviceName, 'test expectation');
+        if (!range) {
+            assert.fail('unable to get partial affinity range');
+            return;
+        }
         // assert.comment(self.hostPort + ' affineWorkers: ' + range.affineWorkers);
         // assert.comment(self.hostPort + ' hostPort: ' + opts.hostPort);
         expectedConnectedOut = range.affineWorkers.indexOf(opts.hostPort) > -1;


### PR DESCRIPTION
After deploying and canarying #66 we saw CPU saturation due to
`Array.prototype.sort`.  Caching the sorted workers should help since the
sorted relays are already cached.

cc @raynos @rf