### PR TITLE
Downgrade erorr log about empty affine workers

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -772,11 +772,12 @@ function ensurePartialConnections(chan, serviceName, reason, now) {
     }
 
     if (!range.affineWorkers.length) {
-        self.logger.error('empty affineWorkers, this should not happen', self.extendLogInfo({
+        self.logger.warn('empty affine workers list', self.extendLogInfo({
             serviceName: serviceName,
             reason: reason,
             partialRange: range
         }));
+        // TODO: why not return early
     }
 
     var connectedPeers = self.connectedServicePeers[serviceName];


### PR DESCRIPTION
Turns out that this is a frequent edge case during transition times.  Full
explanation has not been nailed yet, but downgrading to a warn since this is
only a problem of it persists; what we saw was a brief blip of these at feature
toggle time.

r @raynos @rf