### PR TITLE
Add a second audit path to partial affinity

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -749,7 +749,11 @@ function freshenPartialPeer(peer, serviceName, now) {
                     connectedPeers: objectTuples(connectedPeers)
                 }))
             );
-            connected = now;
+            if (shouldConnect) {
+                connected = now;
+            } else {
+                connected = null;
+            }
         }
     }
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -741,6 +741,7 @@ function freshenPartialPeer(peer, serviceName, now) {
             self.logger.warn(
                 'partial affinity audit fail',
                 self.extendLogInfo(partialRange.extendLogInfo({
+                    path: 'freshenPartialPeer',
                     serviceName: serviceName,
                     serviceHostPort: hostPort,
                     isConnected: isConnected,


### PR DESCRIPTION
This was the source of (flap and then constant under #158) failure out of
`test/forward/dead-remote-reaped.js`.  As yet unexplained why either of our our
partial connected audit sites are necessary.

r @raynos @rf @kriskowal