### PR TITLE
Update hostports tests for thriftrw 3.0.1

### DIFF
--- a/endpoints/index.js
+++ b/endpoints/index.js
@@ -74,7 +74,11 @@ function setupEndpoints(clients, services) {
     /*eslint no-unused-vars: 0*/
     // thrift health endpoint
     var tchannelAsThrift = new TChannelAsThrift({
-        source: '// lul',
+        entryPoint: 'entryPoint',
+        idls: {
+            entryPoint: '// lul'
+        },
+        allowFilesystemAccess: false,
         channel: clients.hyperbahnChannel,
         isHealthy: require('./health').isHealthy
     });

--- a/handler.js
+++ b/handler.js
@@ -24,7 +24,6 @@
 
 var assert = require('assert');
 var util = require('util');
-var fs = require('fs');
 var path = require('path');
 var setTimeout = require('timers').setTimeout;
 var Errors = require('tchannel/errors.js');
@@ -37,10 +36,6 @@ var RELAY_AD_RETRY_TIME = 1 * 1000;
 var RELAY_AD_TIMEOUT = 500;
 
 var RELAY_TIMEOUT = 500;
-
-var thriftSource = fs.readFileSync(
-    path.join(__dirname, 'hyperbahn.thrift'), 'utf8'
-);
 
 module.exports = HyperbahnHandler;
 
@@ -85,7 +80,8 @@ function HyperbahnHandler(options) {
     self.tchannelThrift = TChannelThrift({
         channel: self.channel,
         logger: self.channel.logger,
-        source: thriftSource
+        entryPoint: path.join(__dirname, 'hyperbahn.thrift'),
+        allowFilesystemAccess: true
     });
 
     // TODO replace JSON with real bufrw handlers for this

--- a/test/forward/thrift.js
+++ b/test/forward/thrift.js
@@ -20,11 +20,8 @@
 
 'use strict';
 
-var fs = require('fs');
 var path = require('path');
-var someSpec = fs.readFileSync(
-    path.join(__dirname, 'someSpec.thrift'), 'utf8'
-);
+var someSpecPath = path.join(__dirname, 'someSpec.thrift');
 
 var allocCluster = require('../lib/test-cluster.js');
 
@@ -33,7 +30,7 @@ allocCluster.test('register and forward with thrift', {
     namedRemotes: ['echoRemote'],
     remotes: {
         echoRemote: {
-            thriftSpec: path.join(__dirname, 'someSpec.thrift')
+            thriftSpec: someSpecPath
         }
     }
 }, function t(cluster, assert) {
@@ -43,7 +40,7 @@ allocCluster.test('register and forward with thrift', {
     var steve = cluster.remotes.steve;
     var bob = cluster.remotes.bob;
     var tchannelThrift = TChannelAsThrift({
-        source: someSpec
+        entryPoint: someSpecPath
     });
 
     var remoteCalls = 0;

--- a/test/hyperbahn-client/hostports.js
+++ b/test/hyperbahn-client/hostports.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var DebugLogtron = require('debug-logtron');
-var fs = require('fs');
 var path = require('path');
 
 var TChannelAsThrift = require('tchannel/as/thrift');

--- a/test/hyperbahn-client/hostports.js
+++ b/test/hyperbahn-client/hostports.js
@@ -27,8 +27,10 @@ var path = require('path');
 var TChannelAsThrift = require('tchannel/as/thrift');
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 
-var source = fs.readFileSync(path.join(__dirname, '../../hyperbahn.thrift'), 'utf8');
-var thrift = new TChannelAsThrift({source: source});
+var thrift = new TChannelAsThrift({
+    entryPoint: path.join(__dirname, '../../hyperbahn.thrift'),
+    allowFilesystemAccess: true
+});
 
 module.exports = runTests;
 
@@ -175,8 +177,10 @@ function runTests(HyperbahnCluster) {
             serviceName: 'hyperbahn',
             hasNoParent: true
         });
-        var badSource = fs.readFileSync(path.join(__dirname, 'bad-hyperbahn-empty-req-body.thrift'), 'utf8');
-        var badThrift = new TChannelAsThrift({source: badSource});
+        var badThrift = new TChannelAsThrift({
+            entryPoint: path.join(__dirname, 'bad-hyperbahn-empty-req-body.thrift'),
+            allowFilesystemAccess: true
+        });
         badThrift.send(request,
             'Hyperbahn::discover',
             null,
@@ -216,8 +220,10 @@ function runTests(HyperbahnCluster) {
             serviceName: 'hyperbahn',
             hasNoParent: true
         });
-        var badSource = fs.readFileSync(path.join(__dirname, 'bad-hyperbahn-empty-query.thrift'), 'utf8');
-        var badThrift = new TChannelAsThrift({source: badSource});
+        var badThrift = new TChannelAsThrift({
+            entryPoint: path.join(__dirname, 'bad-hyperbahn-empty-query.thrift'),
+            allowFilesystemAccess: true
+        });
         badThrift.send(request,
             'Hyperbahn::discover',
             null,
@@ -258,8 +264,10 @@ function runTests(HyperbahnCluster) {
             serviceName: 'hyperbahn',
             hasNoParent: true
         });
-        var badSource = fs.readFileSync(path.join(__dirname, 'bad-hyperbahn-no-exception.thrift'), 'utf8');
-        var badThrift = new TChannelAsThrift({source: badSource});
+        var badThrift = new TChannelAsThrift({
+            entryPoint: path.join(__dirname, 'bad-hyperbahn-no-exception.thrift'),
+            allowFilesystemAccess: true
+        });
         badThrift.send(request,
             'Hyperbahn::discover',
             null,

--- a/test/lib/fake-tcollector.js
+++ b/test/lib/fake-tcollector.js
@@ -20,13 +20,8 @@
 
 'use strict';
 
-var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
-
-var spec = fs.readFileSync(
-    path.join(__dirname, 'tcollector.thrift'), 'utf8'
-);
 
 module.exports = FakeTCollector;
 
@@ -43,7 +38,7 @@ function FakeTCollector(options) {
     self.channel = options.channel;
 
     self.thrift = new self.channel.TChannelAsThrift({
-        source: spec
+        entryPoint: path.join(__dirname, 'tcollector.thrift')
     });
 
     self.thrift.register(

--- a/test/lib/test-client.js
+++ b/test/lib/test-client.js
@@ -84,7 +84,13 @@ function jsonSend(testClient, opts, cb) {
 }
 
 function thriftSend(testClient, opts, thriftSource, cb) {
-    var thrift = new TChannelThrift({source: thriftSource});
+    var thrift = new TChannelThrift({
+        entryPoint: 'entryPoint',
+        idls: {
+            entryPoint: thriftSource
+        },
+        allowFilesystemAccess: false
+    });
     testClient._client.waitForIdentified({
         host: testClient.hostPort
     }, onIdentified);

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -24,7 +24,6 @@
 /* eslint max-statements: [2, 40] */
 var console = require('console');
 var process = require('process');
-var fs = require('fs');
 
 var collectParallel = require('collect-parallel/array');
 var CountedReadySignal = require('ready-signal/counted');
@@ -332,15 +331,14 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
 
     if (thriftSpec) {
         var thriftPath = thriftSpec;
-        var thriftSource = fs.readFileSync(thriftPath).toString();
 
         thriftServer = channel.TChannelAsThrift({
-            source: thriftSource,
+            entryPoint: thriftPath,
             channel: serverChannel
         });
 
         thriftClient = channel.TChannelAsThrift({
-            source: thriftSource,
+            entryPoint: thriftPath,
             channel: clientChannel
         });
     } else {


### PR DESCRIPTION
PR to get tests for tchannel-node to pass after upgrading to thriftrw 3.0.1