### PR TITLE
add a socket inspector

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -47,6 +47,7 @@ var HeapDumper = require('./heap-dumper.js');
 var RemoteConfig = require('./remote-config.js');
 var HyperbahnEgressNodes = require('../egress-nodes.js');
 var HyperbahnHandler = require('../handler.js');
+var SocketInspector = require('./socket-inspector.js');
 
 module.exports = ApplicationClients;
 
@@ -105,6 +106,11 @@ function ApplicationClients(options) {
         self.logger = loggerParts.logger;
         self.logReservoir = loggerParts.logReservoir;
     }
+
+    self.socketInspector = SocketInspector({
+        logger: self.logger
+    });
+    self.socketInspector.enable();
 
     /*eslint no-process-env: 0*/
     var uncaughtTimeouts = config.get('clients.uncaught-exception.timeouts');
@@ -324,6 +330,7 @@ function bootstrap(cb) {
 ApplicationClients.prototype.destroy = function destroy() {
     var self = this;
 
+    self.socketInspector.disable();
     self.serviceProxy.destroy();
     self.remoteConfig.destroy();
     self.ringpop.destroy();
@@ -353,6 +360,7 @@ function updateMaxTombstoneTTL() {
 
 ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdate() {
     var self = this;
+    self.setSocketInspector();
     self.updateMaxTombstoneTTL();
     self.updateLazyHandling();
     self.updateCircuitsEnabled();
@@ -368,6 +376,21 @@ ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdat
     self.updatePartialAffinityEnabled();
     self.setMaximumRelayTTL();
     self.updatePeerHeapEnabled();
+};
+
+ApplicationClients.prototype.setSocketInspector =
+function setSocketInspector() {
+    var self = this;
+
+    var socketInspectorEnabled = self.remoteConfig.get(
+        'clients.socket-inspector.enabled', false
+    );
+
+    if (socketInspectorEnabled) {
+        self.socketInspector.enable();
+    } else {
+        self.socketInspector.disable();
+    }
 };
 
 ApplicationClients.prototype.setMaximumRelayTTL =

--- a/clients/socket-inspector.js
+++ b/clients/socket-inspector.js
@@ -1,0 +1,146 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var Socket = require('net').Socket;
+var socketEmit = Socket.prototype.emit;
+
+var assert = require('assert');
+var WrappedError = require('error/wrapped');
+
+var UnexpectedSocketError = WrappedError({
+    type: 'unexpected-socket-error',
+    message: 'Got unexpected socket error: {causeMessage}'
+});
+
+module.exports = SocketInspector;
+
+function SocketInspector(opts) {
+    if (!(this instanceof SocketInspector)) {
+        return new SocketInspector(opts);
+    }
+
+    var self = this;
+
+    assert(opts.logger, 'logger required');
+    self.logger = opts.logger;
+
+    self.enabled = false;
+    self.boundInspectEmit = boundInspectEmit;
+
+    function boundInspectEmit() {
+        // pass this=socket & arguments=args to inspector
+        self.inspectEmit(this, arguments);
+    }
+}
+
+SocketInspector.prototype.enable = function enable() {
+    var self = this;
+
+    if (self.enabled) {
+        return;
+    }
+
+    Socket.prototype.emit = self.boundInspectEmit;
+};
+
+SocketInspector.prototype.disable = function disable() {
+    var self = this;
+
+    if (!self.enabled) {
+        return;
+    }
+
+    Socket.prototype.emit = socketEmit;
+};
+
+SocketInspector.prototype.inspectEmit =
+function inspectEmit(socket, args) {
+    var self = this;
+
+    var type = args[0];
+    if (type === 'error' && (
+        !socket._events.error ||
+        (typeof socket._events.error === 'object' &&
+            !socket._events.error.length)
+    )) {
+        var originalError = args[1];
+        var error = UnexpectedSocketError(originalError);
+
+        var info = {
+            error: error,
+            remoteAddr: socket.address(),
+            readEnded: socket._readableState.ended,
+            writeEnded: socket._writableState.ended,
+            dataListenerName: null,
+            dataListenerSource: null,
+            closeListenerName: null,
+            closeListenerSource: null,
+            readBufferHead: null,
+            writeBufferHead: null,
+            writeBufferHeadCallbackName: null,
+            writeBufferHeadCallbackSource: null
+        };
+
+        var dataListener = getFirstListener(socket, 'data');
+        if (dataListener) {
+            info.dataListenerName = dataListener.name;
+            info.dataListenerSource = dataListener.toString().slice(0, 64);
+        }
+
+        var closeListener = getFirstListener(socket, 'close');
+        if (closeListener) {
+            info.closeListenerName = closeListener.name;
+            info.closeListenerSource = closeListener.toString().slice(0, 64);
+        }
+
+        if (socket._readableState.buffer.length) {
+            var buf = socket._readableState.buffer[0];
+            info.readBufferHead = buf ? buf.toString('hex') : null;
+        }
+
+        if (socket._writableState.buffer.length) {
+            var entry = socket._writableState.buffer[0];
+            info.writeBufferHead = entry ? entry.buffer.toString('hex') : null;
+            info.writeBufferHeadCallbackSource = entry ?
+                entry.callback.toString().slice(0, 64) : null;
+            info.writeBufferHeadCallbackName = entry ?
+                entry.callback.name : null;
+        }
+
+        self.logger.error('socket emitted error but no listener', info);
+    }
+
+    return socketEmit.apply(socket, args);
+};
+
+function getFirstListener(object, eventName) {
+    var value = object._events[eventName];
+    if (!value) {
+        return null;
+    }
+
+    if (typeof value === 'function') {
+        return value;
+    } else if (typeof value === 'object') {
+        return value.length === 0 ? null : value[0];
+    }
+}


### PR DESCRIPTION
We get really annoying errors in production because we
forgot to add an "error" listener to a Socket somewhere
in the process.

```
Error: read ECONNRESET
    at errnoException (net.js:904:11)
    at TCP.onread (net.js:558:19)
```

To be able to debug this I'm monkey patching the 
Socket.prototype.emit method to allow us to intercept it.

When we intercept it we do two things:

 - create a new wrapped error to get more stack frames
 - log everything about the socket that errored

r: @shannili @rf @jcorbin