### PR TITLE
Upgrade uncaught to latest

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -112,11 +112,11 @@ function ApplicationClients(options) {
         logger: self.logger,
         statsd: self.statsd,
         statsdKey: 'uncaught-exception',
-        prefix: [
-            config.get('info.project'),
-            process.env.NODE_ENV,
-            os.hostname().split('.')[0]
-        ].join('.') + ' ',
+        meta: {
+            project: config.get('info.project'),
+            environment: process.env.NODE_ENV,
+            hostname: os.hostname().split('.')[0]
+        },
         backupFile: config.get('clients.uncaught-exception.file'),
         loggerTimeout: uncaughtTimeouts.loggerTimeout,
         statsdTimeout: uncaughtTimeouts.statsdTimeout,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tape-cluster": "2.0.1",
     "tchannel": "3.5.39",
     "uber-statsd-client": "1.4.0",
-    "uncaught-exception": "5.0.0",
+    "uncaught-exception": "6.0.2",
     "xtend": "4.0.0"
   },
   "devDependencies": {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -211,7 +211,7 @@ TestCluster.prototype.bootstrap = function bootstrap(cb) {
 
         self.forEachHostPort(function each(name, i, hp) {
             name = name.toUpperCase() + i;
-            console.log('TEST SETUP: ' + name + ' ' + hp);
+            console.error('TEST SETUP: ' + name + ' ' + hp);
         });
 
         cb();


### PR DESCRIPTION
`uncaught-exception` now contains a new feature of printing
the current stack whenever an uncaught exception happens.

This helps debugging errors with really small stack traces
like any TCP exceptions.

r: @jcorbin @rf @shannili