### PR TITLE
Add a benchmark mode which spams peer refresh (the meat of advertise)

### DIFF
--- a/benchmarks/config/relay-ad-partial.json
+++ b/benchmarks/config/relay-ad-partial.json
@@ -1,0 +1,9 @@
+{
+    "_extends": "relay-ad.json",
+    "remoteConfig": [
+        {
+            "key": "partialAffinity.enabled",
+            "value": true
+        }
+    ]
+}

--- a/benchmarks/config/relay-ad.json
+++ b/benchmarks/config/relay-ad.json
@@ -1,0 +1,5 @@
+{
+    "_extends": "relay.json",
+    "refreshServicePeersPeriod": 10,
+    "instances": 100
+}

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -76,13 +76,14 @@ HyperbahnWorker.prototype.start = function start() {
         if (err) {
             throw err;
         }
+        refreshServicePeers();
+    }
 
+    function refreshServicePeers() {
         var basePort = self.serverPort;
         var serviceProxy = self.app.clients.serviceProxy;
-
         for (var i = 0; i < self.instances; i++) {
             var targetHostPort = '127.0.0.1:' + (basePort + i);
-
             serviceProxy.refreshServicePeer(
                 self.serverServiceName, targetHostPort
             );

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var clearTimeout = require('timers').clearTimeout;
+var setTimeout = require('timers').setTimeout;
 var process = require('process');
 var assert = require('assert');
 var path = require('path');
@@ -58,6 +60,9 @@ function HyperbahnWorker(opts) {
     self.remoteConfigFile = RemoteConfigFile(String(self.serverPort));
     self.remoteConfigFile.write(opts.remoteConfig);
 
+    self.refreshServicePeersPeriod = opts.refreshServicePeersPeriod || 0;
+    self.refreshServicePeersTimer = null;
+
     self.config = self.createConfig();
     self.app = HyperbahnApplication(self.config, {
         processTitle: process.title,
@@ -77,9 +82,18 @@ HyperbahnWorker.prototype.start = function start() {
             throw err;
         }
         refreshServicePeers();
+        self.app.on('destroy', onAppDestroyed);
+    }
+
+    function onAppDestroyed() {
+        clearTimeout(self.refreshServicePeersTimer);
+        self.refreshServicePeersTimer = null;
     }
 
     function refreshServicePeers() {
+        clearTimeout(self.refreshServicePeersTimer);
+        self.refreshServicePeersTimer = null;
+
         var basePort = self.serverPort;
         var serviceProxy = self.app.clients.serviceProxy;
         for (var i = 0; i < self.instances; i++) {
@@ -87,6 +101,10 @@ HyperbahnWorker.prototype.start = function start() {
             serviceProxy.refreshServicePeer(
                 self.serverServiceName, targetHostPort
             );
+        }
+
+        if (self.refreshServicePeersPeriod) {
+            self.refreshServicePeersTimer = setTimeout(refreshServicePeers, self.refreshServicePeersPeriod);
         }
     }
 };

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -82,6 +82,7 @@ function spawnRelayServer() {
     self.startFakeSentry();
 
     var procOpts = [
+        '--refreshServicePeersPeriod', self.opts.refreshServicePeersPeriod,
         '--serverPort', String(self.ports.serverPort),
         '--serverServiceName', String(self.serviceName),
         '--instances', String(self.instanceCount),


### PR DESCRIPTION
Going forward it'd be great to have this be more "realistic" by actually going through the RPC handler path, but this was achievable and useful for tuning partial affinity.

r @Raynos @rf