### PR TITLE
Reduce cardinality of ringpop stats

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -322,6 +322,7 @@ function setupRingpop(cb) {
         pingTimeout: self.ringpopTimeouts.pingTimeout,
         joinTimeout: self.ringpopTimeouts.joinTimeout
     });
+    self.ringpop.statPrefix = 'ringpop.hyperbahn';
     self.ringpop.setupChannel();
 
     self.egressNodes.setRingpop(self.ringpop);


### PR DESCRIPTION
Ringpop emits stats that contain the `host_port` dimension. We
change the `statPrefix` to remove this `host_port` dimension
and reduce cardinality in ringpop stats.

r: @jcorbin @rf