### PR TITLE
Pare down and limit use of secondary indices

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1543,7 +1543,7 @@ function disableRateLimiter() {
 };
 
 ServiceDispatchHandler.prototype.setPartialAffinityEnabled =
-function enablePartialAffinity(enabled) {
+function setPartialAffinityEnabled(enabled) {
     var self = this;
     self.partialAffinityEnabled = !!enabled;
     self.partialRanges = Object.create(null);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1547,6 +1547,8 @@ function setPartialAffinityEnabled(enabled) {
     var self = this;
     self.partialAffinityEnabled = !!enabled;
     self.partialRanges = Object.create(null);
+    self.connectedServicePeers = Object.create(null);
+    self.connectedPeerServices = Object.create(null);
 };
 
 ServiceDispatchHandler.prototype.extendLogInfo =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1331,10 +1331,9 @@ function reapSinglePeer(hostPort, serviceNames) {
     for (var i = 0; i < serviceNames.length; i++) {
         var serviceName = serviceNames[i];
         var serviceChannel = self.getServiceChannel(serviceName);
-        if (!serviceChannel) {
-            return;
+        if (serviceChannel) {
+            serviceChannel.peers.delete(hostPort);
         }
-        serviceChannel.peers.delete(hostPort);
         self.deletePeerIndex(serviceName, hostPort);
         delete self.partialRanges[serviceName];
     }


### PR DESCRIPTION
- only update them under the partial affinity path
- drop one of them entirely in lieu of some smaller sub-objects on `PartialRange`
- fix a potential bug under `reapSinglePeer`

r @raynos @rf
cc @kriskowal