### PR TITLE
rewrite traffic to global stats client

### DIFF
--- a/clients/batch-stats.js
+++ b/clients/batch-stats.js
@@ -1,0 +1,116 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var timers = require('timers');
+var os = require('os');
+var util = require('util');
+
+var BatchStatsd = require('tchannel/lib/statsd');
+
+module.exports = HyperbahnBatchStatsd;
+
+function HyperbahnBatchStatsd(opts) {
+    if (!(this instanceof HyperbahnBatchStatsd)) {
+        return new HyperbahnBatchStatsd(opts);
+    }
+
+    var self = this;
+
+    BatchStatsd.call(self, {
+        statsd: opts.statsd,
+        logger: opts.logger,
+        timers: timers,
+        baseTags: {
+            app: 'autobahn',
+            host: os.hostname()
+        }
+    });
+}
+util.inherits(HyperbahnBatchStatsd, BatchStatsd);
+
+HyperbahnBatchStatsd.prototype.handleStat =
+function handleStat(stat) {
+    /*eslint complexity: [2, 50]*/
+    var self = this;
+
+    if (!self.statsd) {
+        return;
+    } else if (isNullStatsd(self.statsd)) {
+        self.writeToStatsd(self.statsd, stat);
+        return;
+    }
+
+    if (
+        stat.name === 'tchannel.inbound.calls.recvd' ||
+        stat.name === 'tchannel.inbound.request.size' ||
+        stat.name === 'tchannel.inbound.request.size' ||
+        stat.name === 'tchannel.inbound.calls.latency' ||
+        stat.name === 'tchannel.inbound.calls.system-errors' ||
+        stat.name === 'tchannel.inbound.response.size' ||
+        stat.name === 'tchannel.inbound.calls.latency' ||
+        stat.name === 'tchannel.inbound.calls.success' ||
+        stat.name === 'tchannel.inbound.calls.app-errors' ||
+        stat.name === 'tchannel.inbound.response.size'
+    ) {
+        self.writeToStatsd(self.statsd.globalClient, stat);
+    } else if (
+        stat.name === 'tchannel.outbound.request.size' ||
+        stat.name === 'tchannel.outbound.calls.sent' ||
+        stat.name === 'tchannel.outbound.request.size' ||
+        stat.name === 'tchannel.outbound.calls.per-attempt-latency' ||
+        stat.name === 'tchannel.outbound.calls.per-attempt.operational-errors' ||
+        stat.name === 'tchannel.outbound.calls.system-errors' ||
+        stat.name === 'tchannel.outbound.response.size' ||
+        stat.name === 'tchannel.outbound.calls.per-attempt-latency' ||
+        stat.name === 'tchannel.outbound.calls.success' ||
+        stat.name === 'tchannel.outbound.calls.per-attempt.app-errors' ||
+        stat.name === 'tchannel.outbound.response.size'
+    ) {
+        self.writeToStatsd(self.statsd.globalClient, stat);
+    } else {
+        self.writeToStatsd(self.statsd, stat);
+    }
+};
+
+HyperbahnBatchStatsd.prototype.writeToStatsd =
+function writeToStatsd(statsd, stat) {
+    var self = this;
+
+    var key = stat.tags.toStatKey(stat.name);
+
+    if (stat.type === 'counter') {
+        statsd.increment(key, stat.value);
+    } else if (stat.type === 'gauge') {
+        statsd.gauge(key, stat.value);
+    } else if (stat.type === 'timing') {
+        statsd.timing(key, stat.value);
+    } else {
+        self.logger.error('Trying to emit an invalid stat object', {
+            statType: stat.type,
+            statName: stat.name
+        });
+    }
+};
+
+function isNullStatsd(statsd) {
+    return !!statsd._buffer;
+}

--- a/clients/dual-statsd.js
+++ b/clients/dual-statsd.js
@@ -64,6 +64,15 @@ function DualStatsd(options) {
         packetQueue: options.packetQueue || null,
         socketTimeout: options.socketTimeout || null
     });
+    self.globalClient = new Statsd({
+        host: options.host,
+        port: options.port,
+        prefix: [
+            options.project,
+            'all-workers',
+            process.env.NODE_ENV
+        ]
+    });
 }
 
 DualStatsd.prototype.gauge = function gauge(name, value) {

--- a/clients/index.js
+++ b/clients/index.js
@@ -22,7 +22,6 @@
 
 var assert = require('assert');
 var http = require('http');
-var timers = require('timers');
 // TODO use better module. This sometimes fails when you
 // move around and change wifi networks.
 var myLocalIp = require('my-local-ip');
@@ -37,7 +36,6 @@ var fs = require('fs');
 var ProcessReporter = require('process-reporter');
 var NullStatsd = require('uber-statsd-client/null');
 var extendInto = require('xtend/mutable');
-var BatchStatsd = require('tchannel/lib/statsd');
 
 var ServiceProxy = require('../service-proxy.js');
 var createLogger = require('./logger.js');
@@ -48,6 +46,7 @@ var RemoteConfig = require('./remote-config.js');
 var HyperbahnEgressNodes = require('../egress-nodes.js');
 var HyperbahnHandler = require('../handler.js');
 var SocketInspector = require('./socket-inspector.js');
+var HyperbahnBatchStats = require('./batch-stats.js');
 
 module.exports = ApplicationClients;
 
@@ -141,14 +140,9 @@ function ApplicationClients(options) {
         res.end('OK');
     }
 
-    self.batchStats = new BatchStatsd({
+    self.batchStats = HyperbahnBatchStats({
         statsd: self.statsd,
-        logger: self.logger,
-        timers: timers,
-        baseTags: {
-            app: 'autobahn',
-            host: os.hostname()
-        }
+        logger: self.logger
     });
     self.batchStats.flushStats();
 


### PR DESCRIPTION
The cardinality of our metrics is insane. This change
removes the host/worker cardinality from our inbound
and outbound stats.

r: @rf @shannili @robskillington