### PR TITLE
do not emit edge-rps stats at all

### DIFF
--- a/rate_limiter.js
+++ b/rate_limiter.js
@@ -197,7 +197,7 @@ function refresh() {
     );
 
     self.refreshEachCounter(self.edgeCounters,
-        'tchannel.rate-limiting.edge-rps',
+        null,
         null,
         createEdgeTag,
         true


### PR DESCRIPTION
This removes a bunch of unique metrics that are hard to scale

r: @rf @jcorbin