### PR TITLE
service-proxy: implement routing delegate header

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -48,7 +48,7 @@ function HyperbahnBenchmarkRunner(opts) {
     if (self.opts.multi) {
         self.startClientDelay = 5000;
     } else {
-        self.startClientDelay = 500;
+        self.startClientDelay = 1000;
     }
 
     self.ports.relayServerPort = RELAY_SERVER_PORT;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -432,7 +432,7 @@ function handleRequest(req, buildRes) {
                 }))
             );
             if (rd) {
-                buildRes().sendError('Busy', 'Routing delegate ' + rd + ' is rate-limited by the rps of ' + serviceLimit);
+                buildRes().sendError('Busy', 'Routing delegate ' + rd + ' is rate-limited by the service rps of ' + serviceLimit);
             } else {
                 buildRes().sendError('Busy', req.serviceName + ' is rate-limited by the service rps of ' + serviceLimit);
             }

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -302,11 +302,6 @@ function handleLazily(conn, reqFrame) {
 
     var rdBuf = res.value && res.value.getValue(RD_HEADER_BUFFER);
     var rd = rdBuf && rdBuf.toString();
-    if (rd) {
-        // routing delegate header; forward this to the routing service to
-        // delegate to
-        return self._callLazyHandler(rd, conn, reqFrame);
-    }
 
     var cnBuf = res.value && res.value.getValue(CN_HEADER_BUFFER);
     var cn = cnBuf && cnBuf.toString();
@@ -359,16 +354,10 @@ function handleLazily(conn, reqFrame) {
         }
     }
 
-    return self._callLazyHandler(serviceName, conn, reqFrame);
-};
-
-ServiceDispatchHandler.prototype._callLazyHandler =
-function _callLazyHandler(serviceName, conn, reqFrame) {
-    var self = this;
-
-    var serviceChannel = self.channel.subChannels[serviceName];
+    // use the rd (routing delegate) or the serviceName if there was no rd set
+    var serviceChannel = self.channel.subChannels[rd || serviceName];
     if (!serviceChannel) {
-        serviceChannel = self.createServiceChannel(serviceName);
+        serviceChannel = self.createServiceChannel(rd || serviceName);
     }
 
     if (serviceChannel.handler.handleLazily) {

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -254,7 +254,7 @@ function handleLazily(conn, reqFrame) {
     var self = this;
 
     /*eslint max-statements: [2, 45]*/
-    /*eslint complexity: [2, 15]*/
+    /*eslint complexity: [2, 17]*/
 
     var res = reqFrame.bodyRW.lazy.readService(reqFrame);
     if (res.err) {

--- a/test/forward/routing-delegate.js
+++ b/test/forward/routing-delegate.js
@@ -1,0 +1,77 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var allocCluster = require('../lib/test-cluster.js');
+
+allocCluster.test('routing delegate', {
+    size: 5
+}, function t(cluster, assert) {
+    var steve = cluster.remotes.steve;
+    var bob = cluster.remotes.bob;
+
+    cluster.checkExitPeers(assert, {
+        serviceName: steve.serviceName,
+        hostPort: steve.hostPort
+    });
+
+    var TChannelAsJSON = cluster.dummies[0].TChannelAsJSON;
+
+    var steveTCollectorSubchannel = steve.channel.makeSubChannel({
+        serviceName: 'tcollector'
+    });
+
+    var tchannelJSON = TChannelAsJSON({logger: cluster.logger});
+    tchannelJSON.register(steveTCollectorSubchannel, 'echo', {}, handleEcho);
+
+    var steveReceived = false;
+
+    function handleEcho(opts, req, head, body, cb) {
+        steveReceived = true;
+
+        cb(null, {
+            ok: true,
+            head: null,
+            body: body
+        });
+    }
+
+    bob.clientChannel.request({
+        serviceName: 'tcollector',
+        headers: {
+            rd: 'steve',
+            as: 'json'
+        }
+    }).send('echo', null, JSON.stringify('oh hi lol'), onForwarded);
+
+    function onForwarded(err, res, arg2, arg3) {
+        if (err) {
+            assert.ifError(err);
+            return assert.end();
+        }
+
+        assert.equal(String(arg3), '"oh hi lol"');
+
+        assert.ok(steveReceived, 'steve received request');
+
+        assert.end();
+    }
+});

--- a/test/index.js
+++ b/test/index.js
@@ -62,6 +62,7 @@ require('./forward/forwarding-huge-buffer.js');
 require('./forward/forwarding-respects-relay-flags.js');
 require('./forward/forwarding-under-membershipchange-is-non-event.js');
 require('./forward/dead-remote-reaped.js');
+require('./forward/routing-delegate.js');
 
 require('./hosts/happy-path.js');
 require('./hosts/no-body.js');


### PR DESCRIPTION
r @Raynos @jcorbin 

If there's a routing delegate we defer to it as soon as possible.

Should this actually hit the rate limiting logic, at least for total RPS?