### PR TITLE
Fixes for benchmark torching

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,7 +1,7 @@
 take-%: results/%.json
 	echo "Done $< -> $$(readlink -f $<)"
 
-torch-%: results/%.svg
+torch-%: results/HEAD/%.svg
 	echo "Done $< -> $$(readlink -f $<)"
 
 results/%.json: results/HEAD/%.json
@@ -33,6 +33,6 @@ kill-dead-benchmarks:
 top-benchmark:
 	top -d1 -cp `pgrep -f nodejs-benchmarks | tr "\\n" "," | sed 's/,$$//'`;
 
-.PRECIOUS: results/%.json results/HEAD/%.json results/%.raw results/HEAD/%.raw
+.PRECIOUS: results/%.json results/HEAD/%.json results/%.raw results/HEAD/%.raw results/%.svg results/HEAD/%.svg
 
 .PHONY: results/HEAD create-flame kill-dead-benchmarks top-benchmark

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -28,7 +28,7 @@ results/HEAD/%.raw: config/%.json results/HEAD kill-dead-benchmarks
 	flamegraph.pl $< > $@
 
 kill-dead-benchmarks:
-	pkill -f '^nodejs-benchmarks' || true
+	pkill -u $$USER -f '^nodejs-benchmarks' || true
 
 top-benchmark:
 	top -d1 -cp `pgrep -f nodejs-benchmarks | tr "\\n" "," | sed 's/,$$//'`;

--- a/benchmarks/config/relay.json
+++ b/benchmarks/config/relay.json
@@ -2,7 +2,7 @@
     "relay": true,
     "skipPing": true,
 
-    "sizes": [4096],
+    "sizes": [4096,16384],
     "pipeline": [10],
 
     "remoteConfig": [

--- a/benchmarks/config/torch.json
+++ b/benchmarks/config/torch.json
@@ -1,4 +1,5 @@
 {
     "torch": "relay",
-    "torchTime": 10
+    "torchTime": 10,
+    "noEndpointOverhead": true
 }


### PR DESCRIPTION
- fix the target to make the right file
- turn off endpoint overhead so that we have a hope of finishing at small
  pipeline value
- don't try to kill other users' processes
- restore 16KiB size so that we don't halt before torch period is over