### PR TITLE
Drop drop "refresh peer partially" info log

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -803,16 +803,6 @@ function freshenPartialPeer(peer, serviceName, now) {
     } else {
         self.ensurePeerDisconnected(serviceName, peer, 'service peer affinity refresh', now);
     }
-
-    self.logger.info(
-        'refreshed peer partially',
-        self.extendLogInfo({
-            serviceName: serviceName,
-            serviceHostPort: hostPort,
-            numConnectedPeers: countKeys(connectedPeers),
-            isConnected: connected
-        })
-    );
 };
 
 ServiceDispatchHandler.prototype.ensurePartialConnections =


### PR DESCRIPTION
This is another drastic improvement to the `relay-ad-partial` benchmark.