### PR TITLE
Defer opening all peer connections.

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -460,6 +460,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateReservoir(hasChanged, forceUpdate);
     self.updateReapPeersPeriod(hasChanged, forceUpdate);
     self.updatePrunePeersPeriod(hasChanged, forceUpdate);
+    self.updateConnectPeersPeriod(hasChanged, forceUpdate);
     self.updatePartialAffinityEnabled(hasChanged, forceUpdate);
     self.setMaximumRelayTTL(hasChanged, forceUpdate);
     self.updatePeerHeapEnabled(hasChanged, forceUpdate);
@@ -575,6 +576,15 @@ function updatePrunePeersPeriod(hasChanged, forceUpdate) {
     if (forceUpdate || hasChanged['peerPruner.period']) {
         var period = self.remoteConfig.get('peerPruner.period', 0);
         self.serviceProxy.setPrunePeersPeriod(period);
+    }
+};
+
+ApplicationClients.prototype.updateConnectPeersPeriod =
+function updateConnectPeersPeriod(hasChanged, forceUpdate) {
+    var self = this;
+    if (forceUpdate || hasChanged['peerConnecter.period']) {
+        var period = self.remoteConfig.get('peerConnecter.period', 100);
+        self.serviceProxy.setConnectPeersPeriod(period);
     }
 };
 


### PR DESCRIPTION
Connections are now opened in smeared batches every `100ms` (configurable by `peerConnecter.period`).

This will mitigate CPU load under heavy advertise spam, worker churn, or internal hyperbahn topology change.

r @Raynos @rf