### PR TITLE
discovery: Fix Hyperbahn::discover to not have a loop

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -447,10 +447,13 @@ function _forwardToRemoteDiscover(parent, svcchan, body, cb) {
 
     function handleForward(err, resp) {
         if (err) {
-            self.channel.logger.error('Failed to call discover API on exit node', {
-                error: err,
-                serviceName: serviceName
-            });
+            self.channel.logger.error(
+                'Failed to call discover API on exit node',
+                parent.extendLogInfo({
+                    error: err,
+                    serviceName: serviceName
+                })
+            );
             return cb(err, null);
         }
 

--- a/handler.js
+++ b/handler.js
@@ -438,8 +438,10 @@ function _forwardToRemoteDiscover(parent, svcchan, body, cb) {
             cn: 'hyperbahn'
         },
         parent: parent,
-        timeout: 5000,
-        timeoutPerAttempt: 500,
+        retryFlags: {
+            never: true
+        },
+        timeout: 1000,
         trace: false
     }), endpoint, null, body, handleForward);
 

--- a/handler.js
+++ b/handler.js
@@ -422,11 +422,7 @@ function discover(handler, req, head, body, cb) {
             cb(null, resp);
         });
     } else {
-        svcchan = handler.channel.topChannel.subChannels[serviceName];
-        var hosts = [];
-        if (svcchan) {
-            hosts = convertHosts(svcchan.peers.keys());
-        }
+        var hosts = handler._getDiscoverHosts(serviceName);
         if (hosts.length === 0) {
             cb(null, {
                 ok: false,
@@ -435,13 +431,27 @@ function discover(handler, req, head, body, cb) {
                 }),
                 typeName: 'noPeersAvailable'
             });
-        } else {
-            cb(null, {
-                ok: true,
-                body: {
-                    peers: hosts
-                }
-            });
+            return;
         }
+
+        cb(null, {
+            ok: true,
+            body: {
+                peers: hosts
+            }
+        });
     }
+};
+
+HyperbahnHandler.prototype._getDiscoverHosts =
+function _getDiscoverHosts(serviceName) {
+    var self = this;
+
+    var hosts = [];
+    var svcchan = self.channel.topChannel.subChannels[serviceName];
+    if (svcchan) {
+        hosts = convertHosts(svcchan.peers.keys());
+    }
+
+    return hosts;
 };

--- a/handler.js
+++ b/handler.js
@@ -402,24 +402,7 @@ function discover(handler, req, head, body, cb) {
         return;
     }
 
-    var hosts = handler._getDiscoverHosts(serviceName);
-    if (hosts.length === 0) {
-        cb(null, {
-            ok: false,
-            body: NoPeersAvailable({
-                serviceName: serviceName
-            }),
-            typeName: 'noPeersAvailable'
-        });
-        return;
-    }
-
-    cb(null, {
-        ok: true,
-        body: {
-            peers: hosts
-        }
-    });
+    handler._getDiscoverHosts(serviceName, cb);
 };
 
 HyperbahnHandler.prototype._forwardToRemoteDiscover =
@@ -454,7 +437,7 @@ function _forwardToRemoteDiscover(parent, svcchan, body, cb) {
 };
 
 HyperbahnHandler.prototype._getDiscoverHosts =
-function _getDiscoverHosts(serviceName) {
+function _getDiscoverHosts(serviceName, cb) {
     var self = this;
 
     var hosts = [];
@@ -463,5 +446,21 @@ function _getDiscoverHosts(serviceName) {
         hosts = convertHosts(svcchan.peers.keys());
     }
 
-    return hosts;
+    if (hosts.length === 0) {
+        cb(null, {
+            ok: false,
+            body: NoPeersAvailable({
+                serviceName: serviceName
+            }),
+            typeName: 'noPeersAvailable'
+        });
+        return;
+    }
+
+    cb(null, {
+        ok: true,
+        body: {
+            peers: hosts
+        }
+    });
 };

--- a/hyperbahn.thrift
+++ b/hyperbahn.thrift
@@ -32,4 +32,11 @@ service Hyperbahn {
         1: NoPeersAvailable noPeersAvailable
         2: InvalidServiceName invalidServiceName
     )
+
+    DiscoveryResult discoverAffine(
+        1: required DiscoveryQuery query
+    ) throws (
+        1: NoPeersAvailable noPeersAvailable
+        2: InvalidServiceName invalidServiceName
+    )
 }

--- a/test/hyperbahn-client/hostports.js
+++ b/test/hyperbahn-client/hostports.js
@@ -130,6 +130,39 @@ function runTests(HyperbahnCluster) {
         }
     });
 
+    HyperbahnCluster.test('get host port for steve', {
+        size: 5
+    }, function t(cluster, assert) {
+        var steve = cluster.remotes.steve;
+
+        var steveSub = steve.channel.subChannels.hyperbahn;
+        var request = steveSub.request({
+            headers: {
+                cn: 'test'
+            },
+            serviceName: 'hyperbahn',
+            hasNoParent: true
+        });
+
+        thrift.send(request, 'Hyperbahn::discover', null, {
+            query: {
+                serviceName: 'steve'
+            }
+        }, check);
+
+        function check(err, res) {
+            if (err) {
+                assert.end(err);
+            }
+
+            assert.ok(res, 'should be a result');
+            assert.ok(res.ok, 'result should be ok');
+            assert.equals(covertHost(res.body.peers[0]), steve.channel.hostPort,
+                'should get the expected hostPort');
+            assert.end();
+        }
+    });
+
     HyperbahnCluster.test('malformed thrift IDL: empty serviceName', {
         size: 5
     }, function t(cluster, assert) {


### PR DESCRIPTION
This fixes two issues:

 - Instead of doing an RPC loop have two methods, one
	which terminates
 - To avoid retry storms disable retries.

This PR also fixed a bunch of annoying testing things
in test-cluster at the top of the commit history, I can
break those out into a seperate PR.

r: @jcorbin @kriskowal