### PR TITLE
Log `willSample` prepublish replacer

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test-repeat": "NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; while [ $? -eq 0 ]; do NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; done;",
     "test-cover": "istanbul cover test/index.js",
     "view-cover": "opn ./coverage/index.html",
-    "prepublish": "git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js"
+    "prepublish": "git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs -L 1 node replacer.js"
   },
   "engines": {
     "node": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "test-ci": "npm run check-licence && npm run lint -s && npm run cover",
     "test-repeat": "NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; while [ $? -eq 0 ]; do NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; done;",
     "test-cover": "istanbul cover test/index.js",
-    "view-cover": "opn ./coverage/index.html"
+    "view-cover": "opn ./coverage/index.html",
+    "prepublish": "git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js"
   },
   "engines": {
     "node": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "test-repeat": "NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; while [ $? -eq 0 ]; do NODE_DEBUG=autobahn node test/index.js | FORCE_COLOR=1 tap-spec; done;",
     "test-cover": "istanbul cover test/index.js",
     "view-cover": "opn ./coverage/index.html",
-    "prepublish": "git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs -L 1 node replacer.js"
+    "prepublish": "git ls-files | grep '.js$' | grep -v 'bin/' | grep -v test | grep -v replacer.js | xargs node replacer.js"
   },
   "engines": {
     "node": "0.10.x"

--- a/replacer.js
+++ b/replacer.js
@@ -1,5 +1,29 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
 var fs = require('fs');
 
+// Inserts an if (logger.willSample('level')) before a logsite for a particular
+// level
 function replace(level, line) {
     if (line.indexOf('logger.' + level) !== -1) {
         var matches = line.match(/( *)([a-z\.]*logger).[a-z]*(.*)/);
@@ -31,4 +55,5 @@ for (i = 0; i < contents.length; i++) {
     }
 }
 
+// Modify file in-place
 fs.writeFileSync(input, contents.join('\n'));

--- a/replacer.js
+++ b/replacer.js
@@ -87,3 +87,7 @@ function main(argv) {
         }
     }
 }
+
+if (require.main === module) {
+    main(process.argv);
+}

--- a/replacer.js
+++ b/replacer.js
@@ -1,0 +1,34 @@
+var fs = require('fs');
+
+function replace(level, line) {
+    if (line.indexOf('logger.' + level) !== -1) {
+        var matches = line.match(/( *)([a-z\.]*logger).[a-z]*\((.*)/);
+        if (!matches) {
+            throw new Error('couldn\'t match log line in replacer.js');
+        }
+        var whitespace = matches[1];
+        var logger = matches[2];
+        var restOfLine = matches[3];
+
+        var ifStatement = whitespace + 'if (' + logger + '.willSample(\'' + level + '\')) ';
+        var logCall = logger + '.s' + level + '(' + restOfLine;
+
+        return ifStatement + logCall;
+    } else {
+        return line;
+    }
+}
+
+var input = process.argv[2];
+var contents = fs.readFileSync(input, 'utf8').split('\n');
+var i;
+var levels = ['debug', 'info', 'warn', 'error', 'trace'];
+for (i = 0; i < contents.length; i++) {
+    if (contents[i].indexOf('logger.') !== -1) {
+        levels.forEach(function eachLevel(level) {
+            contents[i] = replace(level, contents[i]);
+        });
+    }
+}
+
+fs.writeFileSync(input, contents.join('\n'));

--- a/replacer.js
+++ b/replacer.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 
 function replace(level, line) {
     if (line.indexOf('logger.' + level) !== -1) {
-        var matches = line.match(/( *)([a-z\.]*logger).[a-z]*\((.*)/);
+        var matches = line.match(/( *)([a-z\.]*logger).[a-z]*(.*)/);
         if (!matches) {
             throw new Error('couldn\'t match log line in replacer.js');
         }
@@ -11,7 +11,7 @@ function replace(level, line) {
         var restOfLine = matches[3];
 
         var ifStatement = whitespace + 'if (' + logger + '.willSample(\'' + level + '\')) ';
-        var logCall = logger + '.s' + level + '(' + restOfLine;
+        var logCall = logger + '.s' + level + restOfLine;
 
         return ifStatement + logCall;
     } else {


### PR DESCRIPTION
This requires an updated larch so it isn't ready to land yet, but it works.

Wrote a simple script to insert `willSample` checks before log lines. I messed around with using some macro systems (sweet.js and the C preprocessor) but found that neither would work. The replacer script is an inelegant solution but it's short and it works.