### PR TITLE
Faster frame reading in ServiceProxy

### DIFF
--- a/benchmarks/config/relay.json
+++ b/benchmarks/config/relay.json
@@ -3,7 +3,9 @@
     "skipPing": true,
 
     "sizes": [4096,16384],
-    "pipeline": [5000, 10000],
+    "pipeline": [1000],
+    "cheatClient": true,
+    "cheatServer": true,
 
     "remoteConfig": [
         {

--- a/benchmarks/config/relay.json
+++ b/benchmarks/config/relay.json
@@ -3,7 +3,7 @@
     "skipPing": true,
 
     "sizes": [4096,16384],
-    "pipeline": [10],
+    "pipeline": [5000, 10000],
 
     "remoteConfig": [
         {

--- a/benchmarks/hyperbahn-worker.js
+++ b/benchmarks/hyperbahn-worker.js
@@ -130,7 +130,7 @@ HyperbahnWorker.prototype.createConfig = function createConfig() {
                 leafPort: self.kafkaPort
             },
             'clients.logtron.logFile': null,
-            // 'clients.logtron.console': true,
+            'clients.logtron.console': true,
             'clients.logtron.sentry': {
                 id: 'http://bs:bs@localhost:' + self.sentryPort
             },

--- a/clients/index.js
+++ b/clients/index.js
@@ -109,7 +109,6 @@ function ApplicationClients(options) {
     self.socketInspector = SocketInspector({
         logger: self.logger
     });
-    self.socketInspector.enable();
 
     /*eslint no-process-env: 0*/
     var uncaughtTimeouts = config.get('clients.uncaught-exception.timeouts');

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
-    "tchannel": "3.6.6",
+    "tchannel": "3.6.7",
     "uber-statsd-client": "1.4.0",
     "uncaught-exception": "6.0.2",
     "xtend": "4.0.0"

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -23,7 +23,6 @@
 /* eslint-disable max-statements */
 
 var assert = require('assert');
-var Buffer = require('buffer').Buffer;
 var RelayHandler = require('tchannel/relay_handler');
 var EventEmitter = require('tchannel/lib/event_emitter');
 var clean = require('tchannel/lib/statsd').clean;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -50,9 +50,6 @@ var RATE_LIMIT_TOTAL = 'total';
 var RATE_LIMIT_SERVICE = 'service';
 var RATE_LIMIT_KILLSWITCH = 'killswitch';
 
-var CN_HEADER_BUFFER = new Buffer('cn');
-var RD_HEADER_BUFFER = new Buffer('rd');
-
 function ServiceDispatchHandler(options) {
     if (!(this instanceof ServiceDispatchHandler)) {
         return new ServiceDispatchHandler(options);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -266,58 +266,29 @@ function handleLazily(conn, reqFrame) {
     /*eslint max-statements: [2, 45]*/
     /*eslint complexity: [2, 17]*/
 
-    var res = reqFrame.bodyRW.lazy.readService(reqFrame);
-    if (res.err) {
+    var serviceName = reqFrame.bodyRW.lazy
+        .readServiceStr(reqFrame);
+    if (!serviceName) {
         // TODO: stat?
+        // TODO: reqFrame.extendLogInfo would be nice, especially if it added
+        // things like callerName and arg1
         self.channel.logger.error(
             'failed to lazy read frame serviceName',
-            conn.extendLogInfo({
-                error: res.err
-            })
+            conn.extendLogInfo()
         );
         // TODO: protocol error instead?
         conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'failed to read serviceName');
         return false;
     }
 
-    var serviceName = res.value;
-    if (!serviceName) {
-        // TODO: reqFrame.extendLogInfo would be nice, especially if it added
-        // things like callerName and arg1
-        self.channel.logger.error(
-            'missing service name in lazy frame',
-            conn.extendLogInfo({})
-        );
-        conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'missing serviceName');
-        return false;
-    }
-
-    // TODO: feature support
-    // - blocking
-    // - rate limiting
-
-    res = reqFrame.bodyRW.lazy.readHeaders(reqFrame);
-    if (res.err) {
-        // TODO: stat?
-        self.channel.logger.warn(
-            'failed to lazy read frame headers',
-            conn.extendLogInfo({
-                error: res.err
-            })
-        );
-        // TODO: protocol error instead?
-        conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'failed to read headers');
-        return false;
-    }
-
-    var rdBuf = res.value && res.value.getValue(RD_HEADER_BUFFER);
-    var routingDelegate = rdBuf && rdBuf.toString();
+    var routingDelegate = reqFrame.bodyRW.lazy
+        .readRoutingDelegateStr(reqFrame);
 
     var nextService = routingDelegate || serviceName;
 
-    var cnBuf = res.value && res.value.getValue(CN_HEADER_BUFFER);
-    var cn = cnBuf && cnBuf.toString();
-    if (!cn) {
+    var callerName = reqFrame.bodyRW.lazy.readCallerNameStr(reqFrame);
+
+    if (!callerName) {
         self.channel.logger.warn(
             'request missing cn header',
             conn.extendLogInfo({
@@ -328,13 +299,13 @@ function handleLazily(conn, reqFrame) {
         return false;
     }
 
-    if (self.isBlocked(cn, serviceName)) {
+    if (self.isBlocked(callerName, serviceName)) {
         conn.ops.popInReq(reqFrame.id);
         return null;
     }
 
     if (self.rateLimiterEnabled) {
-        var rateLimitReason = self.rateLimit(cn, nextService);
+        var rateLimitReason = self.rateLimit(callerName, nextService);
 
         if (rateLimitReason === RATE_LIMIT_KILLSWITCH) {
             conn.ops.popInReq(reqFrame.id);

--- a/test/rate-limiter.js
+++ b/test/rate-limiter.js
@@ -154,46 +154,16 @@ allocCluster.test('rps counter works in 1.5 seconds', {
             time: 5
         }, {
             type: 'ms',
-            name: 'tchannel.rate-limiting.kill-switch.total-rps',
-            value: null,
-            delta: null,
-            time: 5
-        }, {
-            type: 'ms',
-            name: 'tchannel.rate-limiting.service-rps.steve',
-            value: null,
-            delta: null,
-            time: 3
-        }, {
-            type: 'ms',
-            name: 'tchannel.rate-limiting.service-rps.bob',
-            value: null,
-            delta: null,
-            time: 2
-        }, {
-            type: 'ms',
-            name: 'tchannel.rate-limiting.kill-switch.service-rps.steve',
-            value: null,
-            delta: null,
-            time: 3
-        }, {
-            type: 'ms',
-            name: 'tchannel.rate-limiting.kill-switch.service-rps.bob',
-            value: null,
-            delta: null,
-            time: 2
-        }, {
-            type: 'ms',
             name: 'tchannel.rate-limiting.total-rps',
             value: null,
             delta: null,
             time: 2
         }, {
             type: 'ms',
-            name: 'tchannel.rate-limiting.kill-switch.total-rps',
+            name: 'tchannel.rate-limiting.service-rps.steve',
             value: null,
             delta: null,
-            time: 2
+            time: 3
         }, {
             type: 'ms',
             name: 'tchannel.rate-limiting.service-rps.steve',
@@ -205,13 +175,43 @@ allocCluster.test('rps counter works in 1.5 seconds', {
             name: 'tchannel.rate-limiting.service-rps.bob',
             value: null,
             delta: null,
+            time: 2
+        }, {
+            type: 'ms',
+            name: 'tchannel.rate-limiting.service-rps.bob',
+            value: null,
+            delta: null,
             time: 1
+        }, {
+            type: 'ms',
+            name: 'tchannel.rate-limiting.kill-switch.total-rps',
+            value: null,
+            delta: null,
+            time: 5
+        }, {
+            type: 'ms',
+            name: 'tchannel.rate-limiting.kill-switch.total-rps',
+            value: null,
+            delta: null,
+            time: 2
+        }, {
+            type: 'ms',
+            name: 'tchannel.rate-limiting.kill-switch.service-rps.steve',
+            value: null,
+            delta: null,
+            time: 3
         }, {
             type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.steve',
             value: null,
             delta: null,
             time: 1
+        }, {
+            type: 'ms',
+            name: 'tchannel.rate-limiting.kill-switch.service-rps.bob',
+            value: null,
+            delta: null,
+            time: 2
         }, {
             type: 'ms',
             name: 'tchannel.rate-limiting.kill-switch.service-rps.bob',
@@ -220,7 +220,13 @@ allocCluster.test('rps counter works in 1.5 seconds', {
             time: 1
         }];
 
-        assert.deepEqual(rateLimitStats, expected,
+        var sortedStats = rateLimitStats.sort(function s(a, b) {
+            return a.name < b.name ? 1 :
+                a.name > b.name ? -1 :
+                a.time < b.time ? 1 : -1;
+        });
+
+        assert.deepEqual(sortedStats, expected,
             'stats keys/values as expected');
 
         assert.end();


### PR DESCRIPTION
This PR updates tchannel and uses our cached reading.

From the benchmarks it looks like 50% faster:

before:
```
jakev@hyperbahn-staging02-sjc1:~/tmp/hyperbahn/benchmarks$ make take-relay
mkdir -p results/$(git rev-parse --short HEAD)
ln -nsf $(git rev-parse --short HEAD) results/$(basename $(git symbolic-ref HEAD))
ln -nsf $(basename $(git symbolic-ref HEAD)) results/HEAD
pkill -u $USER -f '^nodejs-benchmarks' || true
BENCH_CONFIG=config/relay.json,config/take.json node index.js -o results/HEAD/relay.json
running /home/jakev/tmp/tchannel-node/benchmarks/cheat-channel/bench_server[30425]
running /home/jakev/tmp/hyperbahn/benchmarks/hyperbahn-worker[30427]
running /home/jakev/tmp/tchannel-node/benchmarks/multi_bench[30437]
1:  SET str 4KiB,  1000/0 min/max/avg/p95:   91/ 264/ 175.63/ 221.00   3553ms total,  5629.05 ops/sec
1:  SET str 4KiB,  1000/0 min/max/avg/p95:   85/ 259/ 168.80/ 231.00   3398ms total,  5885.82 ops/sec
1:  SET str 4KiB,  1000/0 min/max/avg/p95:   81/ 241/ 159.57/ 214.00   3212ms total,  6226.65 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   82/ 263/ 153.63/ 215.00   3097ms total,  6457.86 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   77/ 248/ 155.81/ 221.00   3146ms total,  6357.28 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   66/ 256/ 154.52/ 225.00   3123ms total,  6404.10 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   44/ 278/ 180.33/ 240.00   3647ms total,  5483.96 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   79/ 315/ 189.74/ 248.00   3866ms total,  5173.31 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   85/ 322/ 190.52/ 261.00   3839ms total,  5209.69 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   83/ 307/ 182.39/ 262.00   3674ms total,  5443.66 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   86/ 317/ 188.10/ 265.00   3797ms total,  5267.32 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   21/ 354/ 188.86/ 256.00   3853ms total,  5190.76 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:   43/ 403/ 226.32/ 313.00   4683ms total,  4270.77 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:   39/ 463/ 224.72/ 300.00   4538ms total,  4407.23 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:   47/ 419/ 217.84/ 288.00   4405ms total,  4540.30 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:   90/ 329/ 216.67/ 287.00   4367ms total,  4579.80 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:   23/ 372/ 218.03/ 299.00   4397ms total,  4548.56 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:   19/ 359/ 210.54/ 292.00   4251ms total,  4704.78 ops/sec
1: SET buf 16KiB,  1000/0 min/max/avg/p95:   82/ 380/ 220.46/ 295.00   4490ms total,  4454.34 ops/sec
1: SET buf 16KiB,  1000/0 min/max/avg/p95:   45/ 491/ 226.88/ 322.00   4600ms total,  4347.83 ops/sec
1: SET buf 16KiB,  1000/0 min/max/avg/p95:   43/ 458/ 226.53/ 297.00   4585ms total,  4362.05 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:   81/ 329/ 216.23/ 289.00   4357ms total,  4590.31 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:   78/ 336/ 215.59/ 297.00   4349ms total,  4598.76 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:   98/ 346/ 220.37/ 304.00   4443ms total,  4501.46 ops/sec
```

after:
```
jakev@hyperbahn-staging02-sjc1:~/tmp/hyperbahn/benchmarks$ make take-relay
mkdir -p results/$(git rev-parse --short HEAD)
ln -nsf $(git rev-parse --short HEAD) results/$(basename $(git symbolic-ref HEAD))
ln -nsf $(basename $(git symbolic-ref HEAD)) results/HEAD
pkill -u $USER -f '^nodejs-benchmarks' || true
BENCH_CONFIG=config/relay.json,config/take.json node index.js -o results/HEAD/relay.json
running /home/jakev/tmp/tchannel-node/benchmarks/cheat-channel/bench_server[33721]
running /home/jakev/tmp/hyperbahn/benchmarks/hyperbahn-worker[33723]
{"level":"warn","message":"got empty ringop bootstrap host list, using null instead"}
running /home/jakev/tmp/tchannel-node/benchmarks/multi_bench[33732]
1:  SET str 4KiB,  1000/0 min/max/avg/p95:   50/ 213/ 125.64/ 189.00   2554ms total,  7830.85 ops/sec
1:  SET str 4KiB,  1000/0 min/max/avg/p95:   42/ 238/ 124.45/ 218.00   2510ms total,  7968.13 ops/sec
1:  SET str 4KiB,  1000/0 min/max/avg/p95:    4/ 249/ 136.34/ 228.00   2752ms total,  7267.44 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   17/ 245/ 137.62/ 208.00   2791ms total,  7165.89 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   38/ 231/ 136.24/ 197.00   2759ms total,  7249.00 ops/sec
1:  GET str 4KiB,  1000/0 min/max/avg/p95:   10/ 327/ 148.98/ 229.00   3015ms total,  6633.50 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   18/ 272/ 152.58/ 237.00   3100ms total,  6451.61 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   32/ 267/ 126.96/ 213.00   2669ms total,  7493.44 ops/sec
1:  SET buf 4KiB,  1000/0 min/max/avg/p95:   54/ 254/ 127.20/ 219.00   2571ms total,  7779.07 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   20/ 240/ 118.10/ 197.00   2390ms total,  8368.20 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   11/ 238/ 121.14/ 191.00   2447ms total,  8173.27 ops/sec
1:  GET buf 4KiB,  1000/0 min/max/avg/p95:   18/ 221/ 124.20/ 194.00   2603ms total,  7683.44 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:    7/ 356/ 183.04/ 291.00   3740ms total,  5347.59 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:   17/ 350/ 164.53/ 278.00   3442ms total,  5810.58 ops/sec
1: SET str 16KiB,  1000/0 min/max/avg/p95:   10/ 363/ 172.77/ 298.00   3525ms total,  5673.76 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:   11/ 295/ 168.38/ 269.00   3409ms total,  5866.82 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:    9/ 307/ 159.05/ 272.00   3221ms total,  6209.25 ops/sec
1: GET str 16KiB,  1000/0 min/max/avg/p95:   28/ 411/ 149.59/ 290.00   3029ms total,  6602.84 ops/sec
1: SET buf 16KiB,  1000/0 min/max/avg/p95:    7/ 378/ 176.30/ 278.00   3565ms total,  5610.10 ops/sec
{"changedKeys":[],"newConfig":{"circuits.enabled":true,"rateLimiting.enabled":true,"rateLimiting.exemptServices":["autobahn","ringpop"],"rateLimiting.totalRpsLimit":50000,"rateLimiting.rpsLimitForServiceName":{"benchmark":50000},"peer-heap.enabled.global":true},"_hostname":"hyperbahn-staging02-sjc1","_pid":33723,"_processTitle":"nodejs-benchmarks-hyperbahn_worker","level":"info","message":"[remote-config] config file changed"}
1: SET buf 16KiB,  1000/0 min/max/avg/p95:   11/ 418/ 166.67/ 289.00   3372ms total,  5931.20 ops/sec
1: SET buf 16KiB,  1000/0 min/max/avg/p95:   14/ 406/ 168.38/ 273.00   3463ms total,  5775.34 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:    6/ 405/ 147.42/ 266.00   2987ms total,  6695.68 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:   15/ 417/ 171.69/ 299.00   3474ms total,  5757.05 ops/sec
1: GET buf 16KiB,  1000/0 min/max/avg/p95:   12/ 323/ 157.25/ 275.00   3176ms total,  6297.23 ops/sec
child exited /home/jakev/tmp/tchannel-node/benchmarks/multi_bench[33732] code 0 signal null
benchmark finished
child exited /home/jakev/tmp/tchannel-node/benchmarks/cheat-channel/bench_server[33721] code 143 signal null
child exited /home/jakev/tmp/hyperbahn/benchmarks/hyperbahn-worker[33723] code 143 signal null
ln -sf $(readlink -f results/HEAD/relay.json) results/relay.json
echo "Done results/relay.json -> $(readlink -f results/relay.json)"
Done results/relay.json -> /home/jakev/tmp/hyperbahn/benchmarks/results/3228d0c/relay.json
```

Also note that the average latency went down :)

 - update tchannel
 - fix flappy test
 - disable socket inspector by default
 - use cheat config in benchmarks
 - update ServiceProxy to use new methods

r: @jcorbin @rf