### PR TITLE
Fix circuit breaker bug from prod.

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -274,7 +274,7 @@ function handleLazily(conn, reqFrame) {
         );
         // TODO: protocol error instead?
         conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'failed to read serviceName');
-        return false;
+        return true;
     }
 
     var routingDelegate = reqFrame.bodyRW.lazy
@@ -292,7 +292,7 @@ function handleLazily(conn, reqFrame) {
             })
         );
         conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'missing cn header');
-        return false;
+        return true;
     }
 
     if (self.isBlocked(callerName, serviceName)) {
@@ -359,7 +359,7 @@ function handleLazily(conn, reqFrame) {
             );
             // TODO: protocol error instead?
             conn.sendLazyErrorFrameForReq(reqFrame, 'BadRequest', 'failed to read arg1');
-            return false;
+            return true;
         }
 
         var circuit = serviceChannel.handler.circuits.getCircuit(
@@ -375,7 +375,7 @@ function handleLazily(conn, reqFrame) {
         circuit.state.onRequest();
     }
 
-    serviceChannel.handler.handleLazily(conn, reqFrame);
+    return serviceChannel.handler.handleLazily(conn, reqFrame);
 };
 
 ServiceDispatchHandler.prototype.handleRequest =

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -660,6 +660,9 @@ function sendRegister(channel, opts, cb) {
             hasNoParent: true,
             trace: false,
             timeout: opts.timeout || 5000,
+            retryFlags: {
+                never: true
+            },
             headers: {
                 'cn': opts.serviceName
             }

--- a/test/register/register-with-slow-affinity.js
+++ b/test/register/register-with-slow-affinity.js
@@ -90,7 +90,10 @@ allocCluster.test('register with slow affine', {
             buckets[e.type]++;
         }
 
-        console.log('b?:', buckets);
+        var declined = buckets['tchannel.declined'];
+        assert.ok(declined >= 30 && declined <= 50,
+            'expected declined to be between 30 & 50 but is: ' + declined
+        );
 
         sendNRegisters(cluster, 20, inspectNoErrors);
     }

--- a/test/register/register-with-slow-affinity.js
+++ b/test/register/register-with-slow-affinity.js
@@ -90,8 +90,8 @@ allocCluster.test('register with slow affine', {
         }
 
         var declined = buckets['tchannel.declined'];
-        assert.ok(declined >= 30 && declined <= 60,
-            'expected declined to be between 30 & 60 but is: ' + declined
+        assert.ok(declined >= 25 && declined <= 60,
+            'expected declined to be between 25 & 60 but is: ' + declined
         );
 
         checkCircuitHealthy();

--- a/test/register/register-with-slow-affinity.js
+++ b/test/register/register-with-slow-affinity.js
@@ -49,6 +49,7 @@ allocCluster.test('register with slow affine', {
     cluster.logger.whitelist(
         'info', 'circuit became unhealthy'
     );
+    cluster.logger.whitelist('warn', 'stale tombstone');
 
     var i;
     var exitNodes = cluster.getExitNodes('hello-bob');


### PR DESCRIPTION
We were double counting the circuit breaker by calling
`circuit.onRequest()` but then noting that we could
not handleLazily and returning early.

This broke the circuit breaker, we also potentially double
count rate limiter.

In fact we do EVERYTHING again for the eager path; I think
this entire code path from "try lazy; oops eager" is going
to be brutally expensive for `ad()` and `relay-ad()`

We may have to port `ad()` and `relay-ad()` to be fully
lazy endpoints for performance reasons.

r: @rf @kriskowal @jcorbin