### PR TITLE
remote-config: add changedKeys and only update if changed

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -240,11 +240,11 @@ function ApplicationClients(options) {
     self.remoteConfig.on('update', onRemoteConfigUpdate);
     // initlialize to default
     self.remoteConfig.loadSync();
-    self.onRemoteConfigUpdate();
+    self.onRemoteConfigUpdate([], true);
     self.remoteConfig.startPolling();
 
-    function onRemoteConfigUpdate() {
-        self.onRemoteConfigUpdate();
+    function onRemoteConfigUpdate(affectedKeys, updateAll) {
+        self.onRemoteConfigUpdate(affectedKeys, updateAll || false);
     }
 }
 
@@ -437,24 +437,83 @@ function updateMaxTombstoneTTL() {
     self.tchannel.setMaxTombstoneTTL(ttl);
 };
 
-ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdate() {
+/*eslint complexity: [2, 40]*/
+ApplicationClients.prototype.onRemoteConfigUpdate =
+function onRemoteConfigUpdate(changedKeys, all) {
     var self = this;
-    self.setSocketInspector();
-    self.updateMaxTombstoneTTL();
-    self.updateLazyHandling();
-    self.updateCircuitsEnabled();
-    self.updateRateLimitingEnabled();
-    self.updateTotalRpsLimit();
-    self.updateExemptServices();
-    self.updateRpsLimitForServiceName();
-    self.updateKValues();
-    self.updateKillSwitches();
-    self.updateReservoir();
-    self.updateReapPeersPeriod();
-    self.updatePrunePeersPeriod();
-    self.updatePartialAffinityEnabled();
-    self.setMaximumRelayTTL();
-    self.updatePeerHeapEnabled();
+
+    var dict = {};
+    for (var i = 0; i < changedKeys.length; i++) {
+        dict[changedKeys[i]] = true;
+    }
+
+    if (all || dict['clients.socket-inspector.enabled']) {
+        self.setSocketInspector();
+    }
+
+    if (all || dict['tchannel.max-tombstone-ttl']) {
+        self.updateMaxTombstoneTTL();
+    }
+
+    if (all || dict['lazy.handling.enabled']) {
+        self.updateLazyHandling();
+    }
+
+    if (all || dict['circuits.enabled']) {
+        self.updateCircuitsEnabled();
+    }
+
+    if (all || dict['rateLimiting.enabled']) {
+        self.updateRateLimitingEnabled();
+    }
+
+    if (all || dict['rateLimiting.totalRpsLimit']) {
+        self.updateTotalRpsLimit();
+    }
+
+    if (all || dict['rateLimiting.exemptServices']) {
+        self.updateExemptServices();
+    }
+
+    if (all || dict['rateLimiting.rpsLimitForServiceName']) {
+        self.updateRpsLimitForServiceName();
+    }
+
+    if (all || dict['kValue.default'] || dict['kValue.services']) {
+        self.updateKValues();
+    }
+
+    if (all || dict.killSwitch) {
+        self.updateKillSwitches();
+    }
+
+    if (all || dict['log.reservoir.size'] ||
+        dict['log.reservoir.flushInterval']
+    ) {
+        self.updateReservoir();
+    }
+
+    if (all || dict['peerReaper.period']) {
+        self.updateReapPeersPeriod();
+    }
+
+    if (all || dict['peerPruner.period']) {
+        self.updatePrunePeersPeriod();
+    }
+
+    if (all || dict['partialAffinity.enabled']) {
+        self.updatePartialAffinityEnabled();
+    }
+
+    if (all || dict['relay.maximum-ttl']) {
+        self.setMaximumRelayTTL();
+    }
+
+    if (all || dict['peer-heap.enabled.services'] ||
+        dict['peer-heap.enabled.global']
+    ) {
+        self.updatePeerHeapEnabled();
+    }
 };
 
 ApplicationClients.prototype.setSocketInspector =

--- a/clients/remote-config.js
+++ b/clients/remote-config.js
@@ -161,9 +161,9 @@ ConfigValues.prototype._updateConfigValues = function _updateConfigValues(newCon
     var oldConfigValues = self._configValues;
 
     self._configValues = newConfig;
-    self.remoteConfig.emit('update');
 
-    var changedKeys = [];
+    var deltaKeys = [];
+    var affectedKeys = [];
 
     // check for values in current newConfig that are different in oldConfig
     var keys = Object.keys(newConfig);
@@ -175,7 +175,8 @@ ConfigValues.prototype._updateConfigValues = function _updateConfigValues(newCon
 
         if (newJSON !== oldJSON) {
             self.remoteConfig.emit('change:' + key);
-            changedKeys.push('update:' + key);
+            deltaKeys.push('update:' + key);
+            affectedKeys.push(key);
         }
     }
 
@@ -186,13 +187,16 @@ ConfigValues.prototype._updateConfigValues = function _updateConfigValues(newCon
 
         if (!(oldKey in newConfig)) {
             self.remoteConfig.emit('change:' + oldKey);
-            changedKeys.push('remove:' + key);
+            deltaKeys.push('remove:' + oldKey);
+            affectedKeys.push(oldKey);
         }
     }
 
+    self.remoteConfig.emit('update', affectedKeys);
+
     if (!self.remoteConfig._inLoadSync) {
         self.logger.info('[remote-config] config file changed', {
-            changedKeys: changedKeys,
+            deltaKeys: deltaKeys,
             newConfig: newConfig
         });
     }


### PR DESCRIPTION
This should make the cluster stabler and should reduce
the spikes in event loop lag when we change flipr.

r: @jcorbin @rf @kriskowal