### PR TITLE
Add tests for tchannel/hyperbahn client

### DIFF
--- a/test/hyperbahn-client/discover.js
+++ b/test/hyperbahn-client/discover.js
@@ -71,7 +71,7 @@ function runTests(HyperbahnCluster) {
         }
 
         function onDiscovered(err, hosts) {
-            assert.error(err, "foo", err);  // Should not have error here
+            assert.ifError(err, 'successful discover should not return error');
 
             assert.deepLooseEqual(hosts, [bob.channel.hostPort]);
 
@@ -97,8 +97,9 @@ function runTests(HyperbahnCluster) {
         discoverClient.discover(null, onDiscovered);
 
         function onDiscovered(err, hosts) {
-            assert.error(!err, "NoPeersAvailable response", "expected NoPeersAvailable error");
-            assert.deepEqual(hosts, [], "expect empty host list");
+            assert.ok(err, 'expected error');
+            assert.equal(err.message, 'no peer available for hello-steve');
+            assert.deepEqual(hosts, [], 'expect empty host list');
 
             discoverClient.destroy();
             assert.end();
@@ -123,8 +124,9 @@ function runTests(HyperbahnCluster) {
         discoverClient.discover({timeout: 100}, onDiscovered);
 
         function onDiscovered(err, hosts) {
-            assert.error(!err, "expect TChannel error");
-            assert.deepEqual(hosts, null, "expect null host list");
+            assert.ok(err, 'expected TChannel error');
+            assert.equal(err.message, 'no such endpoint service="hyperbahn" endpoint="Hyperbahn::discover"');
+            assert.deepEqual(hosts, null, 'expect null host list');
 
             discoverClient.destroy();
             assert.end();

--- a/test/hyperbahn-client/discover.js
+++ b/test/hyperbahn-client/discover.js
@@ -23,14 +23,7 @@
 var DebugLogtron = require('debug-logtron');
 var NullLogtron = require('null-logtron');
 
-var path = require('path');
-var fs = require('fs');
-var crypto = require('crypto');
-
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
-var TChannelThrift = require('tchannel/as/thrift.js');
-
-var thriftSource = fs.readFileSync(path.join(__dirname, '../../hyperbahn.thrift'), 'utf8');
 
 module.exports = runTests;
 

--- a/test/hyperbahn-client/discover.js
+++ b/test/hyperbahn-client/discover.js
@@ -1,0 +1,133 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var DebugLogtron = require('debug-logtron');
+var NullLogtron = require('null-logtron');
+
+var path = require('path');
+var fs = require('fs');
+var crypto = require('crypto');
+
+var HyperbahnClient = require('tchannel/hyperbahn/index.js');
+var TChannelThrift = require('tchannel/as/thrift.js');
+
+var thriftSource = fs.readFileSync(path.join(__dirname, '../../hyperbahn.thrift'), 'utf8');
+
+module.exports = runTests;
+
+if (require.main === module) {
+    runTests(require('../lib/test-cluster.js'));
+}
+
+function runTests(HyperbahnCluster) {
+    HyperbahnCluster.test('discover success', {
+        size: 5
+    }, function t(cluster, assert) {
+        var bob = cluster.remotes.bob;
+        var steve = cluster.remotes.steve;
+
+        var discoverClient;
+
+        var client = new HyperbahnClient({
+            serviceName: 'hello-bob',
+            callerName: 'hello-bob-test',
+            hostPortList: cluster.hostPortList,
+            tchannel: bob.channel,
+            logger: DebugLogtron('hyperbahnClient')
+        });
+
+        client.once('advertised', onAdvertised);
+        client.advertise();
+
+        function onAdvertised() {
+            discoverClient = new HyperbahnClient({
+                serviceName: 'hello-steve',
+                callerName: 'hello-steve-test',
+                hostPortList: cluster.hostPortList,
+                tchannel: steve.channel,
+                logger: DebugLogtron('hyperbahnClient')
+            });
+
+            discoverClient.discover({serviceName: 'hello-bob'}, onDiscovered);
+        }
+
+        function onDiscovered(err, hosts) {
+            assert.error(err, "foo", err);  // Should not have error here
+
+            assert.deepLooseEqual(hosts, [bob.channel.hostPort]);
+
+            client.destroy();
+            discoverClient.destroy();
+            assert.end();
+        }
+    });
+
+    HyperbahnCluster.test('discover no peers', {
+        size: 5
+    }, function t(cluster, assert) {
+        var steve = cluster.remotes.steve;
+
+        var discoverClient = new HyperbahnClient({
+            serviceName: 'hello-steve',
+            callerName: 'hello-steve-test',
+            hostPortList: cluster.hostPortList,
+            tchannel: steve.channel,
+            logger: DebugLogtron('hyperbahnClient')
+        });
+
+        discoverClient.discover(null, onDiscovered);
+
+        function onDiscovered(err, hosts) {
+            assert.error(!err, "NoPeersAvailable response", "expected NoPeersAvailable error");
+            assert.deepEqual(hosts, [], "expect empty host list");
+
+            discoverClient.destroy();
+            assert.end();
+        }
+    });
+
+    HyperbahnCluster.test('discover hard tchannel error', {
+        size: 5
+    }, function t(cluster, assert) {
+        var steve = cluster.dummies[1];
+
+        var discoverClient = new HyperbahnClient({
+            serviceName: 'hello-steve',
+            callerName: 'hello-steve-test',
+            hostPortList: [steve.hostPort],
+            tchannel: steve,
+            // Use a null logger here because the debugger one throws an
+            // exception when an error is logged.
+            logger: NullLogtron('hyperbahnClient')
+        });
+
+        discoverClient.discover({timeout: 100}, onDiscovered);
+
+        function onDiscovered(err, hosts) {
+            assert.error(!err, "expect TChannel error");
+            assert.deepEqual(hosts, null, "expect null host list");
+
+            discoverClient.destroy();
+            assert.end();
+        }
+    });
+}

--- a/test/hyperbahn-client/hostports.js
+++ b/test/hyperbahn-client/hostports.js
@@ -307,15 +307,15 @@ function runTests(HyperbahnCluster) {
 
 test('convertHost decodes addresses correctly', function t(assert) {
     var ipConversionTests = [
-        [{ ip: { type: 'ipv4', ipv4: 0 }, port: 1234 }, '0.0.0.0:1234'],
-        [{ ip: { type: 'ipv4', ipv4: 16843009 }, port: 4321 }, '1.1.1.1:4321'],
-        [{ ip: { type: 'ipv4', ipv4: 16975111 }, port: 0 }, '1.3.5.7:0'],
-        [{ ip: { type: 'ipv4', ipv4: -1 }, port: 7654 }, '255.255.255.255:7654'],
+        [{ip: {type: 'ipv4', ipv4: 0}, port: 1234}, '0.0.0.0:1234'],
+        [{ip: {type: 'ipv4', ipv4: 16843009}, port: 4321}, '1.1.1.1:4321'],
+        [{ip: {type: 'ipv4', ipv4: 16975111}, port: 0}, '1.3.5.7:0'],
+        [{ip: {type: 'ipv4', ipv4: -1}, port: 7654}, '255.255.255.255:7654']
     ];
 
-    ipConversionTests.forEach(function(test) {
-        var expected = test[1];
-        var value = hyperbahnUtils.convertHost(test[0]);
+    ipConversionTests.forEach(function testRow(tt) {
+        var expected = tt[1];
+        var value = hyperbahnUtils.convertHost(tt[0]);
         assert.equal(value, expected);
     });
 

--- a/test/hyperbahn-client/hostports.js
+++ b/test/hyperbahn-client/hostports.js
@@ -24,7 +24,6 @@ var DebugLogtron = require('debug-logtron');
 var fs = require('fs');
 var path = require('path');
 var test = require('tape');
-var hyperbahnUtils = require('tchannel/hyperbahn/utils');
 
 var TChannelAsThrift = require('tchannel/as/thrift');
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
@@ -116,7 +115,7 @@ function runTests(HyperbahnCluster) {
             }
             assert.ok(res, 'should be a result');
             assert.ok(res.ok, 'result should be ok');
-            assert.equals(hyperbahnUtils.convertHost(res.body.peers[0]), bob.channel.hostPort,
+            assert.equals(convertHost(res.body.peers[0]), bob.channel.hostPort,
                 'should get the expected hostPort');
             client.destroy();
             assert.end();
@@ -150,7 +149,7 @@ function runTests(HyperbahnCluster) {
 
             assert.ok(res, 'should be a result');
             assert.ok(res.ok, 'result should be ok');
-            assert.equals(hyperbahnUtils.convertHost(res.body.peers[0]), steve.channel.hostPort,
+            assert.equals(convertHost(res.body.peers[0]), steve.channel.hostPort,
                 'should get the expected hostPort');
             assert.end();
         }
@@ -315,9 +314,18 @@ test('convertHost decodes addresses correctly', function t(assert) {
 
     ipConversionTests.forEach(function testRow(tt) {
         var expected = tt[1];
-        var value = hyperbahnUtils.convertHost(tt[0]);
+        var value = convertHost(tt[0]);
         assert.equal(value, expected);
     });
 
     assert.end();
 });
+
+function convertHost(host) {
+    var res = '';
+    res += ((host.ip.ipv4 >>> 24) & 0xff) + '.';
+    res += ((host.ip.ipv4 >>> 16) & 0xff) + '.';
+    res += ((host.ip.ipv4 >>> 8) & 0xff) + '.';
+    res += (host.ip.ipv4 & 0xff);
+    return res + ':' + host.port;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,7 @@ require('./hyperbahn-client/hyperbahn-down.js')(TestCluster);
 require('./hyperbahn-client/hyperbahn-times-out.js')(TestCluster);
 require('./hyperbahn-client/rate-limiter.js')(TestCluster);
 require('./hyperbahn-client/advertise-with-purge-interval.js')(TestCluster);
+require('./hyperbahn-client/discover.js')(TestCluster);
 
 require('./register/to-connected-node.js');
 require('./register/with-ringpop-divergence.js');


### PR DESCRIPTION
This PR contains tests for the discover call added to the Hyperbahn client in the relevant PR for tchannel-node:
https://github.com/uber/tchannel-node/pull/276

Running tests on this branch relies on a specific version of tchannel-node to be set in package.json, however, that can't be committed until a new release is made in tchannel-node.

When this is ready to merge (after reviews), I'll need you guys to either take over or guide me on what to do next.

Thanks!