### PR TITLE
Generalize circuit shorting, now with visibility

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -463,6 +463,10 @@ function onRemoteConfigUpdate(changedKeys, all) {
         self.updateCircuitsEnabled();
     }
 
+    if (all || dict['circuits.shorts']) {
+        self.updateCircuitShorts();
+    }
+
     if (all || dict['rateLimiting.enabled']) {
         self.updateRateLimitingEnabled();
     }
@@ -579,6 +583,12 @@ ApplicationClients.prototype.updateCircuitsEnabled = function updateCircuitsEnab
     } else {
         self.serviceProxy.disableCircuits();
     }
+};
+
+ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts() {
+    var self = this;
+    var shorts = self.remoteConfig.get('circuits.shorts', null);
+    self.serviceProxy.updateCircuitShorts(shorts);
 };
 
 ApplicationClients.prototype.updateRateLimitingEnabled = function updateRateLimitingEnabled() {

--- a/endpoints/circuits.js
+++ b/endpoints/circuits.js
@@ -31,12 +31,13 @@ function circuitsEndpoint(opts, req, head, body, cb) {
     for (var index = 0; index < circuitTuples.length; index++) {
         var circuitTuple = circuitTuples[index];
         var circuit = circuits.getCircuit.apply(circuits, circuitTuple);
-        var state = circuit.state.type;
+        var state = circuit.state;
         response.push({
             cn: circuit.callerName,
             sn: circuit.serviceName,
             en: circuit.endpointName,
-            healthy: state === 'tchannel.healthy'
+            healthy: state.healthy,
+            shorted: state.type === 'tchannel.shorted'
         });
     }
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -448,11 +448,7 @@ function handleRequest(req, buildRes) {
         serviceChannel = self.createServiceChannel(nextService);
     }
 
-    if (serviceChannel.handler.circuits &&
-        (req.serviceName !== 'hyperbahn' && (
-            req.endpoint !== 'ad' || req.endpoint !== 'relay-ad'
-        ))
-    ) {
+    if (serviceChannel.handler.circuits) {
         var circuit = serviceChannel.handler.circuits.getCircuit(
             req.headers.cn || 'no-cn', req.serviceName, req.endpoint
         );
@@ -1449,7 +1445,11 @@ function initCircuits() {
         statsd: self.statsd,
         random: self.random,
         egressNodes: self.egressNodes,
-        config: self.circuitsConfig
+        config: self.circuitsConfig,
+        shorts: { // TODO: remoteConfig hookup
+           '*~hyperbahn~ad': true,
+           '*~hyperbahn~relay-ad': true
+        }
     });
 };
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -72,6 +72,10 @@ function ServiceDispatchHandler(options) {
 
     self.circuitsEnabled = false;
     self.circuitsConfig = options.circuitsConfig;
+    self.circuitShorts = {
+        '*~hyperbahn~ad': true,
+        '*~hyperbahn~relay-ad': true
+    };
     self.circuits = null;
 
     self.rateLimiter = new RateLimiter({
@@ -1446,11 +1450,28 @@ function initCircuits() {
         random: self.random,
         egressNodes: self.egressNodes,
         config: self.circuitsConfig,
-        shorts: { // TODO: remoteConfig hookup
-           '*~hyperbahn~ad': true,
-           '*~hyperbahn~relay-ad': true
-        }
+        shorts: self.circuitShorts
     });
+};
+
+ServiceDispatchHandler.prototype.updateCircuitShorts =
+function updateCircuitShorts(shorts) {
+    var self = this;
+
+    self.circuitShorts = {
+        '*~hyperbahn~ad': true,
+        '*~hyperbahn~relay-ad': true
+    };
+    if (typeof shorts === 'object' && shorts !== null) {
+        var keys = Object.keys(shorts);
+        for (var i = 0; i < keys.length; ++i) {
+            self.circuitShorts[keys[i]] = shorts[keys[i]];
+        }
+    }
+
+    if (self.circuits) {
+        self.circuits.updateShorts(self.circuitShorts);
+    }
 };
 
 ServiceDispatchHandler.prototype.enableCircuits =

--- a/test/circuits/happy-path.js
+++ b/test/circuits/happy-path.js
@@ -143,6 +143,7 @@ allocCluster.test('request circuit state from endpoint', {
         assert.equals(circuit.sn, 'bob', 'service name');
         assert.equals(circuit.en, 'ifyousayso', 'endpoint name');
         assert.equals(circuit.healthy, false, 'unhealthy');
+        assert.equals(circuit.shorted, false, 'not shorted');
 
         assert.end();
     }


### PR DESCRIPTION
Add a new `"circuits.shorts"` config option which should be a `Map<String,bool>` where each string is a `"caller~service~endpoint"` tuple with simple wildcarding supported.

This is then used to drive a new `ShortedState` circuit state which is an `UnhealthyState` extension which always passes traffic.

cc @kriskowal @rf @raynos