### PR TITLE
Cleanup circuit observability

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1440,46 +1440,10 @@ function onCircuitStateChange(change) {
     if (oldState && oldState.healthy !== state.healthy) {
         // unhealthy -> healthy
         if (state.healthy) {
-            self.statsd.increment('circuits.healthy.total', 1);
-            self.statsd.increment(
-                'circuits.healthy.by-caller.' +
-                    clean(circuit.callerName) + '.' +
-                    clean(circuit.serviceName) + '.' +
-                    clean(circuit.endpointName),
-                1
-            );
-            self.statsd.increment(
-                'circuits.healthy.by-service.' +
-                    clean(circuit.serviceName) + '.' +
-                    clean(circuit.callerName) + '.' +
-                    clean(circuit.endpointName),
-                1
-            );
-            self.logger.info(
-                'circuit returned to good health',
-                self.extendLogInfo(circuit.extendLogInfo({}))
-            );
+            circuit.observeTransition(self.logger, self.statsd, 'healthy', self.extendLogInfo({}));
         // healthy -> unhealthy
         } else {
-            self.statsd.increment('circuits.unhealthy.total', 1);
-            self.statsd.increment(
-                'circuits.unhealthy.by-caller.' +
-                    clean(circuit.callerName) + '.' +
-                    clean(circuit.serviceName) + '.' +
-                    clean(circuit.endpointName),
-                1
-            );
-            self.statsd.increment(
-                'circuits.unhealthy.by-service.' +
-                    clean(circuit.serviceName) + '.' +
-                    clean(circuit.callerName) + '.' +
-                    clean(circuit.endpointName),
-                1
-            );
-            self.logger.info(
-                'circuit became unhealthy',
-                self.extendLogInfo(circuit.extendLogInfo({}))
-            );
+            circuit.observeTransition(self.logger, self.statsd, 'unhealthy', self.extendLogInfo({}));
         }
     }
 };

--- a/test/circuits/circuits.js
+++ b/test/circuits/circuits.js
@@ -68,7 +68,7 @@ RelayNetwork.test('should switch to unhealthy', aliceAndBob, function t(network,
         res.sendError('UnexpectedError', 'head splode');
     });
 
-    network.cluster.logger.whitelist('info', 'circuit became unhealthy');
+    network.cluster.logger.whitelist('info', 'circuit event: unhealthy');
 
     var declined = 0;
     var unexpected = 0;
@@ -99,7 +99,7 @@ RelayNetwork.test('should switch to unhealthy', aliceAndBob, function t(network,
         assert.equal(items.length, 1);
         var logRecord = items[0];
         assert.equal(logRecord.levelName, 'info');
-        assert.equal(logRecord.msg, 'circuit became unhealthy');
+        assert.equal(logRecord.msg, 'circuit event: unhealthy');
         assert.equal(logRecord.meta.serviceName, 'bob');
         assert.equal(logRecord.meta.callerName, 'alice');
 
@@ -353,7 +353,7 @@ RelayNetwork.test('circuit state machine behaves properly', aliceAndBob, functio
         }
 
         var circuit = network.getCircuit(0, 'alice', 'bob', 'call');
-        assert.equals(circuit.state.type, 'tchannel.unhealthy', 'became unhealthy');
+        assert.equals(circuit.state.type, 'tchannel.unhealthy', 'circuit event: unhealthy');
 
         assert.end();
     }

--- a/test/register/register-with-slow-affinity.js
+++ b/test/register/register-with-slow-affinity.js
@@ -46,8 +46,8 @@ allocCluster.test.skip('register with slow affine', {
     cluster.logger.whitelist(
         'warn', 'Relay advertise failed with expected err'
     );
-    cluster.logger.whitelist('info', 'circuit became unhealthy');
-    cluster.logger.whitelist('info', 'circuit returned to good health');
+    cluster.logger.whitelist('info', 'circuit event: unhealthy');
+    cluster.logger.whitelist('info', 'circuit event: healthy');
     cluster.logger.whitelist('warn', 'stale tombstone');
 
     var i;
@@ -104,7 +104,7 @@ allocCluster.test.skip('register with slow affine', {
 
         var circuitHealthy = [];
         for (var j = 0; j < logs.length; j++) {
-            if (logs[j].msg === 'circuit returned to good health') {
+            if (logs[j].msg === 'circuit event: healthy') {
                 circuitHealthy.push(logs[j]);
             }
         }
@@ -174,7 +174,7 @@ allocCluster.test.skip('register with slow affine', {
 
         var circuitUnhealthy = [];
         for (var j = 0; j < logs.length; j++) {
-            if (logs[j].msg === 'circuit became unhealthy') {
+            if (logs[j].msg === 'circuit event: unhealthy') {
                 circuitUnhealthy.push(logs[j]);
             }
         }


### PR DESCRIPTION
Out of #224, claw back stats and log emitting code into the Circuit object from
ServiceProxy.

Slightly changes log messages which will require an update to analysis tooling.

May be marginally faster as it reduces the number of string concats on hot path.