### PR TITLE
Further simplify circuit state change observation

### DIFF
--- a/circuits.js
+++ b/circuits.js
@@ -195,7 +195,14 @@ Circuit.prototype.setState = function setState(StateType) {
         oldState.onDeactivate();
     }
 
-    this.observeTransition(state.name, oldState, state);
+    var statsPrefix = 'circuits.' + state.name;
+    this.root.statsd.increment(statsPrefix + '.total', 1);
+    this.root.statsd.increment(statsPrefix + this.byCallerStatSuffix, 1);
+    this.root.statsd.increment(statsPrefix + this.byServiceStatSuffix, 1);
+    this.root.logger.info('circuit event: ' + state.name, this.extendLogInfo({
+        oldState: oldState ? oldState.type : 'none',
+        state: state ? state.type : 'none'
+    }));
 
     return state;
 };
@@ -205,17 +212,6 @@ Circuit.prototype.extendLogInfo = function extendLogInfo(info) {
     info.serviceName = this.serviceName;
     info.endpointName = this.endpointName;
     return info;
-};
-
-Circuit.prototype.observeTransition =
-function observeTransition(eventName, oldState, state) {
-    this.root.statsd.increment('circuits.' + eventName + '.total', 1);
-    this.root.statsd.increment('circuits.' + eventName + this.byCallerStatSuffix, 1);
-    this.root.statsd.increment('circuits.' + eventName + this.byServiceStatSuffix, 1);
-    this.root.logger.info('circuit event: ' + eventName, this.extendLogInfo({
-        oldState: oldState ? oldState.type : 'none',
-        state: state ? state.type : 'none'
-    }));
 };
 
 module.exports = Circuits;

--- a/circuits.js
+++ b/circuits.js
@@ -217,11 +217,11 @@ Circuit.prototype.extendLogInfo = function extendLogInfo(info) {
 };
 
 Circuit.prototype.observeTransition =
-function observeTransition(logger, statsd, eventName, logInfo) {
-    statsd.increment('circuits.' + eventName + '.total', 1);
-    statsd.increment('circuits.' + eventName + this.byCallerStatSuffix, 1);
-    statsd.increment('circuits.' + eventName + this.byServiceStatSuffix, 1);
-    logger.info('circuit event: ' + eventName, this.extendLogInfo(logInfo));
+function observeTransition(eventName, logInfo) {
+    this.root.statsd.increment('circuits.' + eventName + '.total', 1);
+    this.root.statsd.increment('circuits.' + eventName + this.byCallerStatSuffix, 1);
+    this.root.statsd.increment('circuits.' + eventName + this.byServiceStatSuffix, 1);
+    this.root.logger.info('circuit event: ' + eventName, this.extendLogInfo(logInfo));
 };
 
 module.exports = Circuits;

--- a/circuits.js
+++ b/circuits.js
@@ -88,6 +88,8 @@ ServiceCircuits.prototype.collectCircuitTuples = function collectCircuitTuples(t
 
 function Circuits(options) {
     EventEmitter.call(this);
+    this.logger = options.logger;
+    this.statsd = options.statsd;
     this.circuitStateChangeEvent = this.defineEvent('circuitStateChange');
     this.circuitsByServiceName = {};
     this.config = options.config || {};

--- a/circuits.js
+++ b/circuits.js
@@ -195,15 +195,7 @@ Circuit.prototype.setState = function setState(StateType) {
         oldState.onDeactivate();
     }
 
-    if (oldState && oldState.healthy !== state.healthy) {
-        // unhealthy -> healthy
-        if (state.healthy) {
-            this.observeTransition('healthy', oldState, state);
-        // healthy -> unhealthy
-        } else {
-            this.observeTransition('unhealthy', oldState, state);
-        }
-    }
+    this.observeTransition(state.name, oldState, state);
 
     return state;
 };
@@ -221,6 +213,8 @@ function observeTransition(eventName, oldState, state) {
     this.root.statsd.increment('circuits.' + eventName + this.byCallerStatSuffix, 1);
     this.root.statsd.increment('circuits.' + eventName + this.byServiceStatSuffix, 1);
     this.root.logger.info('circuit event: ' + eventName, this.extendLogInfo({
+        oldState: oldState ? oldState.type : 'none',
+        state: state ? state.type : 'none'
     }));
 };
 
@@ -344,6 +338,7 @@ function HealthyState(options) {
 inherits(HealthyState, PeriodicState);
 
 HealthyState.prototype.type = 'tchannel.healthy';
+HealthyState.prototype.name = 'healthy';
 HealthyState.prototype.healthy = true;
 
 HealthyState.prototype.toString = function healthyToString() {
@@ -433,6 +428,7 @@ function UnhealthyState(options) {
 inherits(UnhealthyState, PeriodicState);
 
 UnhealthyState.prototype.type = 'tchannel.unhealthy';
+UnhealthyState.prototype.name = 'unhealthy';
 UnhealthyState.prototype.healthy = false;
 
 UnhealthyState.prototype.onNewPeriod = function onNewPeriod(now) {

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1440,10 +1440,10 @@ function onCircuitStateChange(change) {
     if (oldState && oldState.healthy !== state.healthy) {
         // unhealthy -> healthy
         if (state.healthy) {
-            circuit.observeTransition(self.logger, self.statsd, 'healthy', self.extendLogInfo({}));
+            circuit.observeTransition('healthy', self.extendLogInfo({}));
         // healthy -> unhealthy
         } else {
-            circuit.observeTransition(self.logger, self.statsd, 'unhealthy', self.extendLogInfo({}));
+            circuit.observeTransition('unhealthy', self.extendLogInfo({}));
         }
     }
 };

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1469,6 +1469,8 @@ function initCircuits() {
     self.circuits = new Circuits({
         timeHeap: self.channel.timeHeap,
         timers: self.channel.timers,
+        logger: self.logger,
+        statsd: self.statsd,
         random: self.random,
         egressNodes: self.egressNodes,
         config: self.circuitsConfig


### PR DESCRIPTION
- no event emitter at all, just inject logger and statsd
- less checking necessary, and more string re-use

NOTE: since we no longer involve `serviceProxy.extendLogInfo` or
`channel.extendLogInfo`, the following log fields have been removed from
circuit state change logs:

```javascript
info.affineServices         = Object.keys(self.exitServices);
info.channelDestroyed       = self.destroyed;
info.channelDraining        = self.draining;
info.channelListened        = self.listened;
info.channelListening       = self.listening;
info.circuitsEnabled        = self.circuitsEnabled;
info.hostPort               = self.hostPort;
info.minPeersPerRelay       = self.minPeersPerRelay;
info.minPeersPerWorker      = self.minPeersPerWorker;
info.partialAffinityEnabled = self.partialAffinityEnabled;
info.rateLimiterEnabled     = self.rateLimiterEnabled;
```

I think this is okay and that we don't need these fields, reviewers please
double check.

r @raynos @kriskowal @rf