### PR TITLE
Fix remote config change encapsulation

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -462,10 +462,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateReapPeersPeriod(hasChanged, forceUpdate);
     self.updatePrunePeersPeriod(hasChanged, forceUpdate);
     self.updatePartialAffinityEnabled(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['relay.maximum-ttl']) {
-        self.setMaximumRelayTTL();
-    }
+    self.setMaximumRelayTTL(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['peer-heap.enabled.services'] ||
         hasChanged['peer-heap.enabled.global']
@@ -490,13 +487,12 @@ function setSocketInspector(hasChanged, forceUpdate) {
 };
 
 ApplicationClients.prototype.setMaximumRelayTTL =
-function setMaximumRelayTTL() {
+function setMaximumRelayTTL(hasChanged, forceUpdate) {
     var self = this;
-
-    var maximumRelayTTL = self.remoteConfig.get(
-        'relay.maximum-ttl', 2 * 60 * 1000
-    );
-    self.tchannel.setMaximumRelayTTL(maximumRelayTTL);
+    if (forceUpdate || hasChanged['relay.maximum-ttl']) {
+        var maximumRelayTTL = self.remoteConfig.get('relay.maximum-ttl', 2 * 60 * 1000);
+        self.tchannel.setMaximumRelayTTL(maximumRelayTTL);
+    }
 };
 
 ApplicationClients.prototype.updateLazyHandling = function updateLazyHandling(hasChanged, forceUpdate) {

--- a/clients/index.js
+++ b/clients/index.js
@@ -451,10 +451,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateMaxTombstoneTTL(hasChanged, forceUpdate);
     self.updateLazyHandling(hasChanged, forceUpdate);
     self.updateCircuitsEnabled(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['circuits.shorts']) {
-        self.updateCircuitShorts();
-    }
+    self.updateCircuitShorts(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['rateLimiting.enabled']) {
         self.updateRateLimitingEnabled();
@@ -580,10 +577,11 @@ ApplicationClients.prototype.updateCircuitsEnabled = function updateCircuitsEnab
     }
 };
 
-ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts() {
+ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts(hasChanged, forceUpdate) {
     var self = this;
-    var shorts = self.remoteConfig.get('circuits.shorts', null);
-    self.serviceProxy.updateCircuitShorts(shorts);
+    if (forceUpdate || hasChanged['circuits.shorts']) {
+        self.serviceProxy.updateCircuitShorts(self.remoteConfig.get('circuits.shorts', null));
+    }
 };
 
 ApplicationClients.prototype.updateRateLimitingEnabled = function updateRateLimitingEnabled() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -439,82 +439,82 @@ function updateMaxTombstoneTTL() {
 
 /*eslint complexity: [2, 40]*/
 ApplicationClients.prototype.onRemoteConfigUpdate =
-function onRemoteConfigUpdate(changedKeys, all) {
+function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     var self = this;
 
-    var dict = {};
+    var hasChanged = {};
     for (var i = 0; i < changedKeys.length; i++) {
-        dict[changedKeys[i]] = true;
+        hasChanged[changedKeys[i]] = true;
     }
 
-    if (all || dict['clients.socket-inspector.enabled']) {
+    if (forceUpdate || hasChanged['clients.socket-inspector.enabled']) {
         self.setSocketInspector();
     }
 
-    if (all || dict['tchannel.max-tombstone-ttl']) {
+    if (forceUpdate || hasChanged['tchannel.max-tombstone-ttl']) {
         self.updateMaxTombstoneTTL();
     }
 
-    if (all || dict['lazy.handling.enabled']) {
+    if (forceUpdate || hasChanged['lazy.handling.enabled']) {
         self.updateLazyHandling();
     }
 
-    if (all || dict['circuits.enabled']) {
+    if (forceUpdate || hasChanged['circuits.enabled']) {
         self.updateCircuitsEnabled();
     }
 
-    if (all || dict['circuits.shorts']) {
+    if (forceUpdate || hasChanged['circuits.shorts']) {
         self.updateCircuitShorts();
     }
 
-    if (all || dict['rateLimiting.enabled']) {
+    if (forceUpdate || hasChanged['rateLimiting.enabled']) {
         self.updateRateLimitingEnabled();
     }
 
-    if (all || dict['rateLimiting.totalRpsLimit']) {
+    if (forceUpdate || hasChanged['rateLimiting.totalRpsLimit']) {
         self.updateTotalRpsLimit();
     }
 
-    if (all || dict['rateLimiting.exemptServices']) {
+    if (forceUpdate || hasChanged['rateLimiting.exemptServices']) {
         self.updateExemptServices();
     }
 
-    if (all || dict['rateLimiting.rpsLimitForServiceName']) {
+    if (forceUpdate || hasChanged['rateLimiting.rpsLimitForServiceName']) {
         self.updateRpsLimitForServiceName();
     }
 
-    if (all || dict['kValue.default'] || dict['kValue.services']) {
+    if (forceUpdate || hasChanged['kValue.default'] || hasChanged['kValue.services']) {
         self.updateKValues();
     }
 
-    if (all || dict.killSwitch) {
+    if (forceUpdate || hasChanged.killSwitch) {
         self.updateKillSwitches();
     }
 
-    if (all || dict['log.reservoir.size'] ||
-        dict['log.reservoir.flushInterval']
+    if (forceUpdate || hasChanged['log.reservoir.size'] ||
+        hasChanged['log.reservoir.flushInterval']
     ) {
         self.updateReservoir();
     }
 
-    if (all || dict['peerReaper.period']) {
+    if (forceUpdate || hasChanged['peerReaper.period']) {
         self.updateReapPeersPeriod();
     }
 
-    if (all || dict['peerPruner.period']) {
+    if (forceUpdate || hasChanged['peerPruner.period']) {
         self.updatePrunePeersPeriod();
     }
 
-    if (all || dict['partialAffinity.enabled']) {
+    if (forceUpdate || hasChanged['partialAffinity.enabled']) {
         self.updatePartialAffinityEnabled();
     }
 
-    if (all || dict['relay.maximum-ttl']) {
+    if (forceUpdate || hasChanged['relay.maximum-ttl']) {
         self.setMaximumRelayTTL();
     }
 
-    if (all || dict['peer-heap.enabled.services'] ||
-        dict['peer-heap.enabled.global']
+    if (forceUpdate || hasChanged['peer-heap.enabled.services'] ||
+        hasChanged['peer-heap.enabled.global']
     ) {
         self.updatePeerHeapEnabled();
     }

--- a/clients/index.js
+++ b/clients/index.js
@@ -450,10 +450,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.setSocketInspector(hasChanged, forceUpdate);
     self.updateMaxTombstoneTTL(hasChanged, forceUpdate);
     self.updateLazyHandling(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['circuits.enabled']) {
-        self.updateCircuitsEnabled();
-    }
+    self.updateCircuitsEnabled(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['circuits.shorts']) {
         self.updateCircuitShorts();
@@ -572,13 +569,14 @@ ApplicationClients.prototype.updateReservoir = function updateReservoir() {
     }
 };
 
-ApplicationClients.prototype.updateCircuitsEnabled = function updateCircuitsEnabled() {
+ApplicationClients.prototype.updateCircuitsEnabled = function updateCircuitsEnabled(hasChanged, forceUpdate) {
     var self = this;
-    var enabled = self.remoteConfig.get('circuits.enabled', false);
-    if (enabled) {
-        self.serviceProxy.enableCircuits();
-    } else {
-        self.serviceProxy.disableCircuits();
+    if (forceUpdate || hasChanged['circuits.enabled']) {
+        if (self.remoteConfig.get('circuits.enabled', false)) {
+            self.serviceProxy.enableCircuits();
+        } else {
+            self.serviceProxy.disableCircuits();
+        }
     }
 };
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -447,9 +447,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
         hasChanged[changedKeys[i]] = true;
     }
 
-    if (forceUpdate || hasChanged['clients.socket-inspector.enabled']) {
-        self.setSocketInspector();
-    }
+    self.setSocketInspector(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['tchannel.max-tombstone-ttl']) {
         self.updateMaxTombstoneTTL();
@@ -521,8 +519,12 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
 };
 
 ApplicationClients.prototype.setSocketInspector =
-function setSocketInspector() {
+function setSocketInspector(hasChanged, forceUpdate) {
     var self = this;
+
+    if (!forceUpdate && !hasChanged['clients.socket-inspector.enabled']) {
+        return;
+    }
 
     var socketInspectorEnabled = self.remoteConfig.get(
         'clients.socket-inspector.enabled', false

--- a/clients/index.js
+++ b/clients/index.js
@@ -437,7 +437,6 @@ function updateMaxTombstoneTTL(hasChanged, forceUpdate) {
     }
 };
 
-/*eslint complexity: [2, 40]*/
 ApplicationClients.prototype.onRemoteConfigUpdate =
 function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     var self = this;

--- a/clients/index.js
+++ b/clients/index.js
@@ -526,11 +526,7 @@ function setSocketInspector(hasChanged, forceUpdate) {
         return;
     }
 
-    var socketInspectorEnabled = self.remoteConfig.get(
-        'clients.socket-inspector.enabled', false
-    );
-
-    if (socketInspectorEnabled) {
+    if (self.remoteConfig.get('clients.socket-inspector.enabled', false)) {
         self.socketInspector.enable();
     } else {
         self.socketInspector.disable();

--- a/clients/index.js
+++ b/clients/index.js
@@ -449,10 +449,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
 
     self.setSocketInspector(hasChanged, forceUpdate);
     self.updateMaxTombstoneTTL(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['lazy.handling.enabled']) {
-        self.updateLazyHandling();
-    }
+    self.updateLazyHandling(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['circuits.enabled']) {
         self.updateCircuitsEnabled();
@@ -540,8 +537,13 @@ function setMaximumRelayTTL() {
     self.tchannel.setMaximumRelayTTL(maximumRelayTTL);
 };
 
-ApplicationClients.prototype.updateLazyHandling = function updateLazyHandling() {
+ApplicationClients.prototype.updateLazyHandling = function updateLazyHandling(hasChanged, forceUpdate) {
     var self = this;
+
+    if (!forceUpdate && !hasChanged['lazy.handling.enabled']) {
+        return;
+    }
+
     var enabled = self.remoteConfig.get('lazy.handling.enabled', true);
     self.tchannel.setLazyRelaying(enabled);
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -463,12 +463,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updatePrunePeersPeriod(hasChanged, forceUpdate);
     self.updatePartialAffinityEnabled(hasChanged, forceUpdate);
     self.setMaximumRelayTTL(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['peer-heap.enabled.services'] ||
-        hasChanged['peer-heap.enabled.global']
-    ) {
-        self.updatePeerHeapEnabled();
-    }
+    self.updatePeerHeapEnabled(hasChanged, forceUpdate);
 };
 
 ApplicationClients.prototype.setSocketInspector =
@@ -655,10 +650,13 @@ ApplicationClients.prototype.updateKillSwitches = function updateKillSwitches(ha
     }
 };
 
-ApplicationClients.prototype.updatePeerHeapEnabled = function updatePeerHeapEnabled() {
+ApplicationClients.prototype.updatePeerHeapEnabled = function updatePeerHeapEnabled(hasChanged, forceUpdate) {
     var self = this;
-    var peerHeapConfig = self.remoteConfig.get('peer-heap.enabled.services', {});
-    var peerHeapGlobalConfig = self.remoteConfig.get('peer-heap.enabled.global', false);
-
-    self.serviceProxy.setPeerHeapEnabled(peerHeapConfig, peerHeapGlobalConfig);
+    if (forceUpdate ||
+        hasChanged['peer-heap.enabled.services'] ||
+        hasChanged['peer-heap.enabled.global']) {
+        var peerHeapConfig = self.remoteConfig.get('peer-heap.enabled.services', {});
+        var peerHeapGlobalConfig = self.remoteConfig.get('peer-heap.enabled.global', false);
+        self.serviceProxy.setPeerHeapEnabled(peerHeapConfig, peerHeapGlobalConfig);
+    }
 };

--- a/clients/index.js
+++ b/clients/index.js
@@ -454,10 +454,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateCircuitShorts(hasChanged, forceUpdate);
     self.updateRateLimitingEnabled(hasChanged, forceUpdate);
     self.updateTotalRpsLimit(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['rateLimiting.exemptServices']) {
-        self.updateExemptServices();
-    }
+    self.updateExemptServices(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['rateLimiting.rpsLimitForServiceName']) {
         self.updateRpsLimitForServiceName();
@@ -617,10 +614,12 @@ ApplicationClients.prototype.updateTotalRpsLimit = function updateTotalRpsLimit(
     }
 };
 
-ApplicationClients.prototype.updateExemptServices = function updateExemptServices() {
+ApplicationClients.prototype.updateExemptServices = function updateExemptServices(hasChanged, forceUpdate) {
     var self = this;
-    var exemptServices = self.remoteConfig.get('rateLimiting.exemptServices', ['autobahn', 'ringpop']);
-    self.serviceProxy.rateLimiter.updateExemptServices(exemptServices);
+    if (forceUpdate || hasChanged['rateLimiting.exemptServices']) {
+        var exemptServices = self.remoteConfig.get('rateLimiting.exemptServices', ['autobahn', 'ringpop']);
+        self.serviceProxy.rateLimiter.updateExemptServices(exemptServices);
+    }
 };
 
 ApplicationClients.prototype.updateRpsLimitForServiceName = function updateRpsLimitForServiceName() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -456,10 +456,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateTotalRpsLimit(hasChanged, forceUpdate);
     self.updateExemptServices(hasChanged, forceUpdate);
     self.updateRpsLimitForServiceName(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['kValue.default'] || hasChanged['kValue.services']) {
-        self.updateKValues();
-    }
+    self.updateKValues(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged.killSwitch) {
         self.updateKillSwitches();
@@ -627,18 +624,23 @@ ApplicationClients.prototype.updateRpsLimitForServiceName = function updateRpsLi
     }
 };
 
-ApplicationClients.prototype.updateKValues = function updateKValues() {
+ApplicationClients.prototype.updateKValues = function updateKValues(hasChanged, forceUpdate) {
     var self = this;
-    var defaultKValue = self.remoteConfig.get('kValue.default', 10);
-    self.egressNodes.setDefaultKValue(defaultKValue);
 
-    var serviceKValues = self.remoteConfig.get('kValue.services', {});
-    var keys = Object.keys(serviceKValues);
-    for (var i = 0; i < keys.length; i++) {
-        var serviceName = keys[i];
-        var kValue = serviceKValues[serviceName];
-        self.egressNodes.setKValueFor(serviceName, kValue);
-        self.serviceProxy.updateServiceChannels();
+    if (forceUpdate || hasChanged['kValue.default']) {
+        var defaultKValue = self.remoteConfig.get('kValue.default', 10);
+        self.egressNodes.setDefaultKValue(defaultKValue);
+    }
+
+    if (forceUpdate || hasChanged['kValue.services']) {
+        var serviceKValues = self.remoteConfig.get('kValue.services', {});
+        var keys = Object.keys(serviceKValues);
+        for (var i = 0; i < keys.length; i++) {
+            var serviceName = keys[i];
+            var kValue = serviceKValues[serviceName];
+            self.egressNodes.setKValueFor(serviceName, kValue);
+            self.serviceProxy.updateServiceChannels();
+        }
     }
 };
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -455,10 +455,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateRateLimitingEnabled(hasChanged, forceUpdate);
     self.updateTotalRpsLimit(hasChanged, forceUpdate);
     self.updateExemptServices(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['rateLimiting.rpsLimitForServiceName']) {
-        self.updateRpsLimitForServiceName();
-    }
+    self.updateRpsLimitForServiceName(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['kValue.default'] || hasChanged['kValue.services']) {
         self.updateKValues();
@@ -622,10 +619,12 @@ ApplicationClients.prototype.updateExemptServices = function updateExemptService
     }
 };
 
-ApplicationClients.prototype.updateRpsLimitForServiceName = function updateRpsLimitForServiceName() {
+ApplicationClients.prototype.updateRpsLimitForServiceName = function updateRpsLimitForServiceName(hasChanged, forceUpdate) {
     var self = this;
-    var rpsLimitForServiceName = self.remoteConfig.get('rateLimiting.rpsLimitForServiceName', {});
-    self.serviceProxy.rateLimiter.updateRpsLimitForAllServices(rpsLimitForServiceName);
+    if (forceUpdate || hasChanged['rateLimiting.rpsLimitForServiceName']) {
+        var rpsLimitForServiceName = self.remoteConfig.get('rateLimiting.rpsLimitForServiceName', {});
+        self.serviceProxy.rateLimiter.updateRpsLimitForAllServices(rpsLimitForServiceName);
+    }
 };
 
 ApplicationClients.prototype.updateKValues = function updateKValues() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -458,12 +458,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateRpsLimitForServiceName(hasChanged, forceUpdate);
     self.updateKValues(hasChanged, forceUpdate);
     self.updateKillSwitches(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['log.reservoir.size'] ||
-        hasChanged['log.reservoir.flushInterval']
-    ) {
-        self.updateReservoir();
-    }
+    self.updateReservoir(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['peerReaper.period']) {
         self.updateReapPeersPeriod();
@@ -537,14 +532,21 @@ ApplicationClients.prototype.updateLazyHandling = function updateLazyHandling(ha
     }
 };
 
-ApplicationClients.prototype.updateReservoir = function updateReservoir() {
+ApplicationClients.prototype.updateReservoir = function updateReservoir(hasChanged, forceUpdate) {
     var self = this;
-    if (self.logReservoir) {
-        var size = self.remoteConfig.get('log.reservoir.size', 100);
-        var interval = self.remoteConfig.get('log.reservoir.flushInterval', 50);
 
-        self.logReservoir.setFlushInterval(interval);
+    if (!self.logReservoir) {
+        return;
+    }
+
+    if (forceUpdate || hasChanged['log.reservoir.size']) {
+        var size = self.remoteConfig.get('log.reservoir.size', 100);
         self.logReservoir.setSize(size);
+    }
+
+    if (forceUpdate || hasChanged['log.reservoir.flushInterval']) {
+        var interval = self.remoteConfig.get('log.reservoir.flushInterval', 50);
+        self.logReservoir.setFlushInterval(interval);
     }
 };
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -429,12 +429,12 @@ ApplicationClients.prototype.destroy = function destroy() {
 };
 
 ApplicationClients.prototype.updateMaxTombstoneTTL =
-function updateMaxTombstoneTTL() {
+function updateMaxTombstoneTTL(hasChanged, forceUpdate) {
     var self = this;
-
-    var ttl = self.remoteConfig.get('tchannel.max-tombstone-ttl', 5000);
-
-    self.tchannel.setMaxTombstoneTTL(ttl);
+    if (forceUpdate || hasChanged['tchannel.max-tombstone-ttl']) {
+        var ttl = self.remoteConfig.get('tchannel.max-tombstone-ttl', 5000);
+        self.tchannel.setMaxTombstoneTTL(ttl);
+    }
 };
 
 /*eslint complexity: [2, 40]*/
@@ -448,10 +448,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     }
 
     self.setSocketInspector(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['tchannel.max-tombstone-ttl']) {
-        self.updateMaxTombstoneTTL();
-    }
+    self.updateMaxTombstoneTTL(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['lazy.handling.enabled']) {
         self.updateLazyHandling();

--- a/clients/index.js
+++ b/clients/index.js
@@ -460,10 +460,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateKillSwitches(hasChanged, forceUpdate);
     self.updateReservoir(hasChanged, forceUpdate);
     self.updateReapPeersPeriod(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['peerPruner.period']) {
-        self.updatePrunePeersPeriod();
-    }
+    self.updatePrunePeersPeriod(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['partialAffinity.enabled']) {
         self.updatePartialAffinityEnabled();
@@ -586,10 +583,12 @@ function updateReapPeersPeriod(hasChanged, forceUpdate) {
 };
 
 ApplicationClients.prototype.updatePrunePeersPeriod =
-function updatePrunePeersPeriod() {
+function updatePrunePeersPeriod(hasChanged, forceUpdate) {
     var self = this;
-    var period = self.remoteConfig.get('peerPruner.period', 0);
-    self.serviceProxy.setPrunePeersPeriod(period);
+    if (forceUpdate || hasChanged['peerPruner.period']) {
+        var period = self.remoteConfig.get('peerPruner.period', 0);
+        self.serviceProxy.setPrunePeersPeriod(period);
+    }
 };
 
 ApplicationClients.prototype.updatePartialAffinityEnabled = function updatePartialAffinityEnabled() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -461,10 +461,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateReservoir(hasChanged, forceUpdate);
     self.updateReapPeersPeriod(hasChanged, forceUpdate);
     self.updatePrunePeersPeriod(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['partialAffinity.enabled']) {
-        self.updatePartialAffinityEnabled();
-    }
+    self.updatePartialAffinityEnabled(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['relay.maximum-ttl']) {
         self.setMaximumRelayTTL();
@@ -591,10 +588,12 @@ function updatePrunePeersPeriod(hasChanged, forceUpdate) {
     }
 };
 
-ApplicationClients.prototype.updatePartialAffinityEnabled = function updatePartialAffinityEnabled() {
+ApplicationClients.prototype.updatePartialAffinityEnabled = function updatePartialAffinityEnabled(hasChanged, forceUpdate) {
     var self = this;
-    var enabled = self.remoteConfig.get('partialAffinity.enabled', false);
-    self.serviceProxy.setPartialAffinityEnabled(enabled);
+    if (forceUpdate || hasChanged['partialAffinity.enabled']) {
+        var enabled = self.remoteConfig.get('partialAffinity.enabled', false);
+        self.serviceProxy.setPartialAffinityEnabled(enabled);
+    }
 };
 
 ApplicationClients.prototype.updateTotalRpsLimit = function updateTotalRpsLimit(hasChanged, forceUpdate) {

--- a/clients/index.js
+++ b/clients/index.js
@@ -453,10 +453,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateCircuitsEnabled(hasChanged, forceUpdate);
     self.updateCircuitShorts(hasChanged, forceUpdate);
     self.updateRateLimitingEnabled(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['rateLimiting.totalRpsLimit']) {
-        self.updateTotalRpsLimit();
-    }
+    self.updateTotalRpsLimit(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['rateLimiting.exemptServices']) {
         self.updateExemptServices();
@@ -612,10 +609,12 @@ ApplicationClients.prototype.updatePartialAffinityEnabled = function updateParti
     self.serviceProxy.setPartialAffinityEnabled(enabled);
 };
 
-ApplicationClients.prototype.updateTotalRpsLimit = function updateTotalRpsLimit() {
+ApplicationClients.prototype.updateTotalRpsLimit = function updateTotalRpsLimit(hasChanged, forceUpdate) {
     var self = this;
-    var limit = self.remoteConfig.get('rateLimiting.totalRpsLimit', 1200);
-    self.serviceProxy.rateLimiter.updateTotalLimit(limit);
+    if (forceUpdate || hasChanged['rateLimiting.totalRpsLimit']) {
+        var limit = self.remoteConfig.get('rateLimiting.totalRpsLimit', 1200);
+        self.serviceProxy.rateLimiter.updateTotalLimit(limit);
+    }
 };
 
 ApplicationClients.prototype.updateExemptServices = function updateExemptServices() {

--- a/clients/index.js
+++ b/clients/index.js
@@ -452,10 +452,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateLazyHandling(hasChanged, forceUpdate);
     self.updateCircuitsEnabled(hasChanged, forceUpdate);
     self.updateCircuitShorts(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['rateLimiting.enabled']) {
-        self.updateRateLimitingEnabled();
-    }
+    self.updateRateLimitingEnabled(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['rateLimiting.totalRpsLimit']) {
         self.updateTotalRpsLimit();
@@ -584,13 +581,14 @@ ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts(
     }
 };
 
-ApplicationClients.prototype.updateRateLimitingEnabled = function updateRateLimitingEnabled() {
+ApplicationClients.prototype.updateRateLimitingEnabled = function updateRateLimitingEnabled(hasChanged, forceUpdate) {
     var self = this;
-    var enabled = self.remoteConfig.get('rateLimiting.enabled', false);
-    if (enabled) {
-        self.serviceProxy.enableRateLimiter();
-    } else {
-        self.serviceProxy.disableRateLimiter();
+    if (forceUpdate || hasChanged['rateLimiting.enabled']) {
+        if (self.remoteConfig.get('rateLimiting.enabled', false)) {
+            self.serviceProxy.enableRateLimiter();
+        } else {
+            self.serviceProxy.disableRateLimiter();
+        }
     }
 };
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -459,10 +459,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateKValues(hasChanged, forceUpdate);
     self.updateKillSwitches(hasChanged, forceUpdate);
     self.updateReservoir(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged['peerReaper.period']) {
-        self.updateReapPeersPeriod();
-    }
+    self.updateReapPeersPeriod(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['peerPruner.period']) {
         self.updatePrunePeersPeriod();
@@ -580,10 +577,12 @@ ApplicationClients.prototype.updateRateLimitingEnabled = function updateRateLimi
 };
 
 ApplicationClients.prototype.updateReapPeersPeriod =
-function updateReapPeersPeriod() {
+function updateReapPeersPeriod(hasChanged, forceUpdate) {
     var self = this;
-    var period = self.remoteConfig.get('peerReaper.period', 0);
-    self.serviceProxy.setReapPeersPeriod(period);
+    if (forceUpdate || hasChanged['peerReaper.period']) {
+        var period = self.remoteConfig.get('peerReaper.period', 0);
+        self.serviceProxy.setReapPeersPeriod(period);
+    }
 };
 
 ApplicationClients.prototype.updatePrunePeersPeriod =

--- a/clients/index.js
+++ b/clients/index.js
@@ -117,7 +117,7 @@ function ApplicationClients(options) {
             statsd: self.statsd
         });
         self.logger = loggerParts.logger;
-        self.logReservoir = loggerParts.logReservoir;
+        self.logReservoir = loggerParts.reservoir;
     }
 
     self.socketInspector = SocketInspector({

--- a/clients/index.js
+++ b/clients/index.js
@@ -457,10 +457,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateExemptServices(hasChanged, forceUpdate);
     self.updateRpsLimitForServiceName(hasChanged, forceUpdate);
     self.updateKValues(hasChanged, forceUpdate);
-
-    if (forceUpdate || hasChanged.killSwitch) {
-        self.updateKillSwitches();
-    }
+    self.updateKillSwitches(hasChanged, forceUpdate);
 
     if (forceUpdate || hasChanged['log.reservoir.size'] ||
         hasChanged['log.reservoir.flushInterval']
@@ -644,8 +641,13 @@ ApplicationClients.prototype.updateKValues = function updateKValues(hasChanged, 
     }
 };
 
-ApplicationClients.prototype.updateKillSwitches = function updateKillSwitches() {
+ApplicationClients.prototype.updateKillSwitches = function updateKillSwitches(hasChanged, forceUpdate) {
     var self = this;
+
+    if (!forceUpdate && !hasChanged.killSwitch) {
+        return;
+    }
+
     self.serviceProxy.unblockAllRemoteConfig();
     var killSwitches = self.remoteConfig.get('killSwitch', []);
 


### PR DESCRIPTION
So that each topic funtion does its own noop checking, bounding the complexit
of the change dispatcher, and allowing for more nuanced handling of changed
keys in a few places.

r @rf @kriskowal