### PR TITLE
Ensure correctness in unadvertise test

### DIFF
--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -98,10 +98,7 @@ function runTests(HyperbahnCluster) {
 
         function onAdvertised() {
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, function readvertise() {
-                steveHyperbahnClient.once('advertised', onReadvertised);
-                steveHyperbahnClient.advertise();
-            });
+            untilAllInConnsRemoved(steve, readvertise);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
             steveHyperbahnClient.unadvertise();
         }
@@ -109,6 +106,11 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
+        }
+
+        function readvertise() {
+            steveHyperbahnClient.once('advertised', onReadvertised);
+            steveHyperbahnClient.advertise();
         }
 
         function onReadvertised() {

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -22,10 +22,10 @@
 
 var DebugLogtron = require('debug-logtron');
 var CountedReadySignal = require('ready-signal/counted');
+var timers = require('timers');
 
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 var TChannelJSON = require('tchannel/as/json');
-// var timers = TimeMock(Date.now());
 
 module.exports = runTests;
 
@@ -129,13 +129,14 @@ function runTests(HyperbahnCluster) {
 }
 
 function untilAllInConnsRemoved(remote, callback) {
-    var count = 0;
+    var count = 1;
     forEachConn(remote, function each(conn) {
         if (conn.direction === 'in') {
             count++;
             waitForClose(conn, onConnClose);
         }
     });
+    timers.setImmediate(onConnClose);
 
     function onConnClose() {
         if (--count <= 0) {

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var DebugLogtron = require('debug-logtron');
+var CountedReadySignal = require('ready-signal/counted');
 
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 var TChannelJSON = require('tchannel/as/json');
@@ -56,10 +57,13 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
+            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, sendSteveRequest);
+            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
+            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
+            unadDone(sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -97,10 +101,13 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
+            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, readvertise);
+            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
+            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
+            unadDone(readvertise);
         }
 
         function onUnadvertised() {


### PR DESCRIPTION
Previously this test didn't handle well the case where there weren't any
connections to be closed, due to tacitly assuming that connections get opened
immediately.

Furthermore it wasn't straightforward to fix this as we were previously
depending on the non-immediate callback of untilAllInConnsRemoved to actually
wait for the unadvertise RPC to finish, rather than actually fencing on its
callback.

r @kriskowal @rf