### PR TITLE
Fix unadvertise test untilExitsConnected utility

### DIFF
--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -250,9 +250,13 @@ function untilExitsConnected(cluster, remote, callback) {
         });
         var gotExits = Object.keys(got).length;
         if (gotExits >= numExists) {
-            remote.channel.connectionEvent.removeListener(checkConns);
-            callback();
+            finish();
         }
+    }
+
+    function finish() {
+        remote.channel.connectionEvent.removeListener(checkConns);
+        callback();
     }
 }
 

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -241,11 +241,8 @@ function untilExitsConnected(cluster, remote, callback) {
     function checkConns() {
         var got = {};
         forEachConn(remote, function each(conn, peer) {
-            var appIndex = cluster.hostPortList.indexOf(peer.hostPort);
-            if (appIndex >= 0) {
-                if (exits[peer.hostPort] !== undefined) {
-                    got[peer.hostPort] = true;
-                }
+            if (exits[peer.hostPort] !== undefined) {
+                got[peer.hostPort] = true;
             }
         });
         var gotExits = Object.keys(got).length;

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -249,7 +249,7 @@ function untilExitsConnected(cluster, remote, callback) {
 
         var got = {};
         forEachConn(remote, function each(conn, peer) {
-            if (exits[peer.hostPort] !== undefined) {
+            if (exits[peer.hostPort] !== undefined && conn.direction === 'in') {
                 got[peer.hostPort] = true;
             }
         });


### PR DESCRIPTION
- only done once we have in-connections from all...
- ...which requires blocking for identified event (since otherwise the
  connection is as-yet unpeered, and not seen by `forEachConn`)
- drop prior `appIndex` logic that is redundant with the cluster exits check
  (since all exits are in `cluster.apps`, just not the converse)

r @rayson @rf @kriskowal