### PR TITLE
Yet more improvements to the unadvertise test

### DIFF
--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -63,7 +63,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            untilAllInConnsRemoved(steve, sendSteveRequest);
+            untilAllExitConnsRemoved(cluster, steve, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -115,7 +115,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            untilAllInConnsRemoved(steve, sendSteveRequest);
+            untilAllExitConnsRemoved(cluster, steve, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -155,7 +155,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            untilAllInConnsRemoved(steve, readvertise);
+            untilAllExitConnsRemoved(cluster, steve, readvertise);
         }
 
         function readvertise() {
@@ -198,7 +198,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            untilAllInConnsRemoved(steve, readvertise);
+            untilAllExitConnsRemoved(cluster, steve, readvertise);
         }
 
         function readvertise() {
@@ -248,10 +248,11 @@ function untilExitsConnected(cluster, remote, callback) {
     }
 }
 
-function untilAllInConnsRemoved(remote, callback) {
+function untilAllExitConnsRemoved(cluster, remote, callback) {
+    var exits = cluster.apps[0].clients.egressNodes.exitsFor(remote.serviceName);
     var count = 1;
-    forEachConn(remote, function each(conn) {
-        if (conn.direction === 'in') {
+    forEachConn(remote, function each(conn, peer) {
+        if (exits[peer.hostPort]) {
             count++;
             waitForClose(conn, onConnClose);
         }

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -74,7 +74,8 @@ function runTests(HyperbahnCluster) {
         }
 
         function onForwarded(err, resp) {
-            assert.ok(err && err.type === 'tchannel.declined' && err.message === 'no peer available for request');
+            assert.equal(err && err.type, 'tchannel.declined', 'expected declined error');
+            assert.equal(err && err.message, 'no peer available for request', 'expected "no peer available for request"');
             steveHyperbahnClient.destroy();
             assert.end();
         }
@@ -126,7 +127,8 @@ function runTests(HyperbahnCluster) {
         }
 
         function onForwarded(err, resp) {
-            assert.ok(err && err.type === 'tchannel.declined' && err.message === 'no peer available for request');
+            assert.equal(err && err.type, 'tchannel.declined', 'expected declined error');
+            assert.equal(err && err.message, 'no peer available for request', 'expected "no peer available for request"');
             steveHyperbahnClient.destroy();
             assert.end();
         }

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -50,7 +50,6 @@ function runTests(HyperbahnCluster) {
             callerName: 'forward-test',
             hostPortList: cluster.hostPortList,
             tchannel: steve.channel,
-            advertiseInterval: 2,
             logger: DebugLogtron('hyperbahnClient')
         });
         steveHyperbahnClient.once('advertised', onAdvertised);
@@ -101,7 +100,6 @@ function runTests(HyperbahnCluster) {
             callerName: 'forward-test',
             hostPortList: cluster.hostPortList,
             tchannel: steve.channel,
-            advertiseInterval: 2,
             logger: DebugLogtron('hyperbahnClient')
         });
 
@@ -150,7 +148,6 @@ function runTests(HyperbahnCluster) {
             callerName: 'forward-test',
             hostPortList: cluster.hostPortList,
             tchannel: steve.channel,
-            advertiseInterval: 2,
             logger: DebugLogtron('hyperbahnClient')
         });
         steveHyperbahnClient.once('advertised', onAdvertised);
@@ -192,7 +189,6 @@ function runTests(HyperbahnCluster) {
             callerName: 'forward-test',
             hostPortList: cluster.hostPortList,
             tchannel: steve.channel,
-            advertiseInterval: 2,
             logger: DebugLogtron('hyperbahnClient')
         });
 

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var DebugLogtron = require('debug-logtron');
-var CountedReadySignal = require('ready-signal/counted');
 var timers = require('timers');
 
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
@@ -56,13 +55,15 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
-            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
-            unadDone(sendSteveRequest);
+        }
+
+        function onUnadvertised() {
+            assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
+            assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
+            untilAllInConnsRemoved(steve, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -70,11 +71,6 @@ function runTests(HyperbahnCluster) {
                 timeout: 5000,
                 serviceName: steve.serviceName
             }), 'echo', null, 'oh hi lol', onForwarded);
-        }
-
-        function onUnadvertised() {
-            assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
-            assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
         }
 
         function onForwarded(err, resp) {
@@ -111,13 +107,15 @@ function runTests(HyperbahnCluster) {
         }
 
         function onceConnected() {
-            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
-            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
-            unadDone(sendSteveRequest);
+        }
+
+        function onUnadvertised() {
+            assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
+            assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
+            untilAllInConnsRemoved(steve, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -125,11 +123,6 @@ function runTests(HyperbahnCluster) {
                 timeout: 5000,
                 serviceName: steve.serviceName
             }), 'echo', null, 'oh hi lol', onForwarded);
-        }
-
-        function onUnadvertised() {
-            assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
-            assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
         }
 
         function onForwarded(err, resp) {
@@ -154,18 +147,15 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
-            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
-            unadDone(readvertise);
         }
 
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
+            untilAllInConnsRemoved(steve, readvertise);
         }
 
         function readvertise() {
@@ -200,18 +190,15 @@ function runTests(HyperbahnCluster) {
         }
 
         function onceConnected() {
-            var unadDone = CountedReadySignal(2);
             assert.equal(steveHyperbahnClient.state, 'ADVERTISED', 'state should be ADVERTISED');
-            untilAllInConnsRemoved(steve, unadDone.signal);
             steveHyperbahnClient.once('unadvertised', onUnadvertised);
-            steveHyperbahnClient.once('unadvertised', unadDone.signal);
             steveHyperbahnClient.unadvertise();
-            unadDone(readvertise);
         }
 
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
+            untilAllInConnsRemoved(steve, readvertise);
         }
 
         function readvertise() {


### PR DESCRIPTION
- drop the 2ms (re)advertise interval: it was never needed, and causes flaps
  once we start injecting more delay by deferring `peer.connectTo`
- tighten then connection removal expectation fence to be all exit connections
  (both in and out), and not just any in-connections
- simplify unadvertise tail flow, turns out we didn't need a counting fence
- trivial improvement to declined assertions for make clearer fail output

r @rf @raynos @kriskowal