### PR TITLE
TestCluster borg untilExits{Connected,Disconnected}

### DIFF
--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -103,7 +103,7 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            cluster.untilExitsConnected(steve, onceConnected);
+            cluster.untilExitsConnected(steve.serviceName, steve.channel, onceConnected);
         }
 
         function onceConnected() {
@@ -187,7 +187,7 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            cluster.untilExitsConnected(steve, onceConnected);
+            cluster.untilExitsConnected(steve.serviceName, steve.channel, onceConnected);
         }
 
         function onceConnected() {

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -104,7 +104,7 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            untilExitsConnected(cluster, steve, onceConnected);
+            cluster.untilExitsConnected(steve, onceConnected);
         }
 
         function onceConnected() {
@@ -188,7 +188,7 @@ function runTests(HyperbahnCluster) {
         steveHyperbahnClient.advertise();
 
         function onAdvertised() {
-            untilExitsConnected(cluster, steve, onceConnected);
+            cluster.untilExitsConnected(steve, onceConnected);
         }
 
         function onceConnected() {
@@ -217,64 +217,27 @@ function runTests(HyperbahnCluster) {
     });
 }
 
-function untilExitsConnected(cluster, remote, callback) {
-    var exits = cluster.apps[0].clients.egressNodes.exitsFor(remote.serviceName);
-    var numExists = Object.keys(exits).length;
-    remote.channel.connectionEvent.on(onConn);
-    checkConns();
-
-    function onConn(conn) {
-        conn.identifiedEvent.on(checkConns);
-    }
-
-    function checkConns(idInfo, newConn) {
-        if (newConn) {
-            newConn.identifiedEvent.removeListener(checkConns);
-        }
-
-        var got = {};
-        forEachConn(remote, function each(conn, peer) {
-            if (exits[peer.hostPort] !== undefined && conn.direction === 'in') {
-                got[peer.hostPort] = true;
-            }
-        });
-        var gotExits = Object.keys(got).length;
-        if (gotExits >= numExists) {
-            finish();
-        }
-    }
-
-    function finish() {
-        remote.channel.connectionEvent.removeListener(onConn);
-        callback();
-    }
-}
-
 function untilAllExitConnsRemoved(cluster, remote, callback) {
     var exits = cluster.apps[0].clients.egressNodes.exitsFor(remote.serviceName);
     var count = 1;
-    forEachConn(remote, function each(conn, peer) {
-        if (exits[peer.hostPort]) {
-            count++;
-            waitForClose(conn, onConnClose);
-        }
-    });
-    timers.setImmediate(onConnClose);
 
-    function onConnClose() {
-        if (--count <= 0) {
-            callback(null);
-        }
-    }
-}
-
-function forEachConn(remote, each) {
     var peers = remote.channel.peers.values();
     for (var i = 0; i < peers.length; i++) {
         var peer = peers[i];
         for (var j = 0; j < peer.connections.length; j++) {
             var conn = peer.connections[j];
-            each(conn, peer);
+            if (exits[peer.hostPort]) {
+                count++;
+                waitForClose(conn, onConnClose);
+            }
+        }
+    }
+
+    timers.setImmediate(onConnClose);
+
+    function onConnClose() {
+        if (--count <= 0) {
+            callback(null);
         }
     }
 }

--- a/test/hyperbahn-client/unadvertise.js
+++ b/test/hyperbahn-client/unadvertise.js
@@ -62,7 +62,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            cluster.untilExitsDisconnected(steve, sendSteveRequest);
+            cluster.untilExitsDisconnected(steve.serviceName, steve.channel, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -115,7 +115,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            cluster.untilExitsDisconnected(steve, sendSteveRequest);
+            cluster.untilExitsDisconnected(steve.serviceName, steve.channel, sendSteveRequest);
         }
 
         function sendSteveRequest() {
@@ -156,7 +156,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            cluster.untilExitsDisconnected(steve, readvertise);
+            cluster.untilExitsDisconnected(steve.serviceName, steve.channel, readvertise);
         }
 
         function readvertise() {
@@ -199,7 +199,7 @@ function runTests(HyperbahnCluster) {
         function onUnadvertised() {
             assert.equal(steveHyperbahnClient.latestAdvertisementResult, null, 'latestAdvertisementResult is null');
             assert.equal(steveHyperbahnClient.state, 'UNADVERTISED', 'state should be UNADVERTISED');
-            cluster.untilExitsDisconnected(steve, readvertise);
+            cluster.untilExitsDisconnected(steve.serviceName, steve.channel, readvertise);
         }
 
         function readvertise() {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -625,14 +625,14 @@ function untilExitsConnected(serviceName, channel, callback) {
 };
 
 TestCluster.prototype.untilExitsDisconnected =
-function untilExitsDisconnected(remote, callback) {
+function untilExitsDisconnected(serviceName, channel, callback) {
     var self = this;
 
     var app = self.apps[0];
-    var exits = app.clients.egressNodes.exitsFor(remote.serviceName);
+    var exits = app.clients.egressNodes.exitsFor(serviceName);
     var count = 1;
 
-    var peers = remote.channel.peers.values();
+    var peers = channel.peers.values();
     for (var i = 0; i < peers.length; i++) {
         var peer = peers[i];
         for (var j = 0; j < peer.connections.length; j++) {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -585,9 +585,22 @@ function untilExitsConnected(serviceName, channel, callback) {
     var self = this;
 
     var app = self.apps[0];
+
     var exits = app.clients.egressNodes.exitsFor(serviceName);
     var numExits = Object.keys(exits).length;
+
+    // Check for all future connections
     channel.connectionEvent.on(onConn);
+
+    // Check for all existing non-identified connections
+    var keys = Object.keys(channel.serverConnections);
+    for (var k = 0; k < keys.length; k++) {
+        var connection = channel.serverConnections[keys[k]];
+        if (!connection.remoteName) {
+            connection.identifiedEvent.on(checkConns);
+        }
+    }
+
     checkConns();
 
     function onConn(conn) {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -384,6 +384,16 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
             return;
         }
 
+        self.untilExitsConnected(remote, onConnected);
+    }
+
+    function onConnected(err) {
+        if (err) {
+            self.logger.error('Failed to get connection from hyperbahn for remote', {
+                error: err
+            });
+            return;
+        }
         cb();
     }
 

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -384,7 +384,7 @@ TestCluster.prototype.createRemote = function createRemote(opts, cb) {
             return;
         }
 
-        self.untilExitsConnected(remote, onConnected);
+        self.untilExitsConnected(remote.serviceName, remote.channel, onConnected);
     }
 
     function onConnected(err) {
@@ -581,13 +581,13 @@ TestCluster.prototype.checkExitKValue = function checkExitKValue(assert, opts) {
 };
 
 TestCluster.prototype.untilExitsConnected =
-function untilExitsConnected(remote, callback) {
+function untilExitsConnected(serviceName, channel, callback) {
     var self = this;
 
     var app = self.apps[0];
-    var exits = app.clients.egressNodes.exitsFor(remote.serviceName);
+    var exits = app.clients.egressNodes.exitsFor(serviceName);
     var numExits = Object.keys(exits).length;
-    remote.channel.connectionEvent.on(onConn);
+    channel.connectionEvent.on(onConn);
     checkConns();
 
     function onConn(conn) {
@@ -601,7 +601,7 @@ function untilExitsConnected(remote, callback) {
 
         var got = {};
 
-        var peers = remote.channel.peers.values();
+        var peers = channel.peers.values();
         for (var i = 0; i < peers.length; i++) {
             var peer = peers[i];
             for (var j = 0; j < peer.connections.length; j++) {
@@ -619,7 +619,7 @@ function untilExitsConnected(remote, callback) {
     }
 
     function finish() {
-        remote.channel.connectionEvent.removeListener(onConn);
+        channel.connectionEvent.removeListener(onConn);
         callback();
     }
 };


### PR DESCRIPTION
- move the hyperbahn-client unad utilities into `TestCluster` methods
- use `untilExitsConnected` in `createRemote` to explicate the current status quo
  before deferring `peer.connectTo` time

r @raynos @rf