### PR TITLE
Change circuit to return Unhealthy

### DIFF
--- a/circuits.js
+++ b/circuits.js
@@ -347,6 +347,14 @@ PeriodicState.prototype.checkPeriod = function checkPeriod(now) {
     return false;
 };
 
+PeriodicState.prototype.getRequestError = function getRequestError() {
+    if (this.shouldRequest()) {
+        return null;
+    }
+
+    return new ErrorFrame('Unhealthy', 'Service is not healthy');
+};
+
 function HealthyState(options) {
     PeriodicState.call(this, options);
 

--- a/circuits.js
+++ b/circuits.js
@@ -157,26 +157,6 @@ Circuits.prototype.getCircuitTuples = function getCircuitTuples() {
     return tuples;
 };
 
-Circuits.prototype.getCircuitForRequest = function getCircuitForRequest(req) {
-    // Default the caller name.
-    // All callers that fail to specifiy a cn share a circuit for each sn:en
-    // and fail together.
-    var callerName = req.headers.cn || 'no-cn';
-    var serviceName = req.serviceName;
-    if (!serviceName) {
-        return new Result(new ErrorFrame('BadRequest', 'All requests must have a service name'));
-    }
-
-    var arg1 = String(req.arg1);
-    var circuit = this.getCircuit(callerName, serviceName, arg1);
-
-    if (!circuit.state.shouldRequest()) {
-        return new Result(new ErrorFrame('Unhealthy', 'Service is not healthy'));
-    }
-
-    return new Result(null, circuit);
-};
-
 function ErrorFrame(codeName, message) {
     this.codeName = codeName;
     this.message = message;

--- a/circuits.js
+++ b/circuits.js
@@ -97,7 +97,7 @@ function Circuits(options) {
     this.statsd = options.statsd;
     this.circuitsByServiceName = {};
     this.config = options.config || {};
-    this.shorts = options.shorts;
+    this.shorts = options.shorts || null;
     this.codeName = options.codeName;
 
     this.stateOptions = new StateOptions(null, {

--- a/circuits.js
+++ b/circuits.js
@@ -171,7 +171,7 @@ Circuits.prototype.getCircuitForRequest = function getCircuitForRequest(req) {
     var circuit = this.getCircuit(callerName, serviceName, arg1);
 
     if (!circuit.state.shouldRequest()) {
-        return new Result(new ErrorFrame('Declined', 'Service is not healthy'));
+        return new Result(new ErrorFrame('Unhealthy', 'Service is not healthy'));
     }
 
     return new Result(null, circuit);

--- a/circuits.js
+++ b/circuits.js
@@ -97,7 +97,8 @@ function Circuits(options) {
     this.statsd = options.statsd;
     this.circuitsByServiceName = {};
     this.config = options.config || {};
-    this.shorts = null;
+    this.shorts = options.shorts;
+    this.codeName = options.codeName;
 
     this.stateOptions = new StateOptions(null, {
         timeHeap: options.timeHeap,
@@ -110,6 +111,10 @@ function Circuits(options) {
     });
     this.egressNodes = options.egressNodes;
 }
+
+Circuits.prototype.updateCodeName = function updateCodeName(codeName) {
+    this.codeName = codeName;
+};
 
 Circuits.prototype.updateShorts = function updateShorts(shorts) {
     this.shorts = parseShorts(shorts);
@@ -351,7 +356,7 @@ PeriodicState.prototype.getRequestError = function getRequestError() {
         return null;
     }
 
-    return new ErrorFrame('Unhealthy', 'Service is not healthy');
+    return new ErrorFrame(this.circuit.root.codeName, 'Service is not healthy');
 };
 
 function HealthyState(options) {

--- a/circuits.js
+++ b/circuits.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var Result = require('bufrw/result');
 var assert = require('assert');
 var format = require('util').format;
 var inherits = require('util').inherits;

--- a/clients/index.js
+++ b/clients/index.js
@@ -451,6 +451,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateLazyHandling(hasChanged, forceUpdate);
     self.updateCircuitsEnabled(hasChanged, forceUpdate);
     self.updateCircuitShorts(hasChanged, forceUpdate);
+    self.updateCircuitCodeName(hasChanged, forceUpdate);
     self.updateRateLimitingEnabled(hasChanged, forceUpdate);
     self.updateTotalRpsLimit(hasChanged, forceUpdate);
     self.updateExemptServices(hasChanged, forceUpdate);
@@ -547,6 +548,16 @@ ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts(
     var self = this;
     if (forceUpdate || hasChanged['circuits.shorts']) {
         self.serviceProxy.updateCircuitShorts(self.remoteConfig.get('circuits.shorts', null));
+    }
+};
+
+ApplicationClients.prototype.updateCircuitCodeName =
+function updateCircuitCodeName(hasChanged, forceUpdate) {
+    var self = this;
+    if (forceUpdate || hasChanged['circuits.codeName']) {
+        self.serviceProxy.updateCircuitCodeName(
+            self.remoteConfig.get('circuits.codeName', 'Declined')
+        );
     }
 };
 

--- a/clients/index.js
+++ b/clients/index.js
@@ -451,7 +451,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updateLazyHandling(hasChanged, forceUpdate);
     self.updateCircuitsEnabled(hasChanged, forceUpdate);
     self.updateCircuitShorts(hasChanged, forceUpdate);
-    self.updateCircuitCodeName(hasChanged, forceUpdate);
+    self.updateCircuitCodeNames(hasChanged, forceUpdate);
     self.updateRateLimitingEnabled(hasChanged, forceUpdate);
     self.updateTotalRpsLimit(hasChanged, forceUpdate);
     self.updateExemptServices(hasChanged, forceUpdate);
@@ -551,12 +551,12 @@ ApplicationClients.prototype.updateCircuitShorts = function updateCircuitShorts(
     }
 };
 
-ApplicationClients.prototype.updateCircuitCodeName =
-function updateCircuitCodeName(hasChanged, forceUpdate) {
+ApplicationClients.prototype.updateCircuitCodeNames =
+function updateCircuitCodeNames(hasChanged, forceUpdate) {
     var self = this;
-    if (forceUpdate || hasChanged['circuits.codeName']) {
-        self.serviceProxy.updateCircuitCodeName(
-            self.remoteConfig.get('circuits.codeName', 'Declined')
+    if (forceUpdate || hasChanged['circuits.codeNames']) {
+        self.serviceProxy.updateCircuitCodeNames(
+            self.remoteConfig.get('circuits.codeNames', {})
         );
     }
 };

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -80,6 +80,7 @@ function ServiceDispatchHandler(options) {
         '*~hyperbahn~ad': true,
         '*~hyperbahn~relay-ad': true
     };
+    self.circuitsCodeName = 'Declined';
     self.circuits = null;
 
     self.rateLimiter = new RateLimiter({
@@ -1502,8 +1503,20 @@ function initCircuits() {
         random: self.random,
         egressNodes: self.egressNodes,
         config: self.circuitsConfig,
-        shorts: self.circuitShorts
+        shorts: self.circuitShorts,
+        codeName: self.circuitsCodeName
     });
+};
+
+ServiceDispatchHandler.prototype.updateCircuitCodeName =
+function updateCircuitCodeName(codeName) {
+    var self = this;
+
+    self.circuitsCodeName = codeName;
+
+    if (self.circuits) {
+        self.circuits.updateCodeName(codeName);
+    }
 };
 
 ServiceDispatchHandler.prototype.updateCircuitShorts =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -425,7 +425,7 @@ function handleLazily(conn, reqFrame) {
             callerName, serviceName, endpoint
         );
         if (!circuit.state.shouldRequest()) {
-            self.rejectRequestFrame(conn, reqFrame, 'Declined', 'Service is not healthy');
+            self.rejectRequestFrame(conn, reqFrame, 'Unhealthy', 'Service is not healthy');
             return true;
         }
 
@@ -516,7 +516,7 @@ function handleRequest(req, buildRes) {
             req.headers.cn || 'no-cn', req.serviceName, req.endpoint
         );
         if (!circuit.state.shouldRequest()) {
-            buildRes().sendError('Declined', 'Service is not healthy');
+            buildRes().sendError('Unhealthy', 'Service is not healthy');
             return;
         }
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -424,8 +424,10 @@ function handleLazily(conn, reqFrame) {
         var circuit = serviceChannel.handler.circuits.getCircuit(
             callerName, serviceName, endpoint
         );
-        if (!circuit.state.shouldRequest()) {
-            self.rejectRequestFrame(conn, reqFrame, 'Unhealthy', 'Service is not healthy');
+        var err = circuit.state.getRequestError();
+        if (err) {
+            self.rejectRequestFrame(conn, reqFrame,
+                err.codeName, err.message);
             return true;
         }
 
@@ -515,8 +517,9 @@ function handleRequest(req, buildRes) {
         var circuit = serviceChannel.handler.circuits.getCircuit(
             req.headers.cn || 'no-cn', req.serviceName, req.endpoint
         );
-        if (!circuit.state.shouldRequest()) {
-            buildRes().sendError('Unhealthy', 'Service is not healthy');
+        var err = circuit.state.getRequestError();
+        if (err) {
+            buildRes().sendError(err.codeName, err.message);
             return;
         }
 

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -80,7 +80,7 @@ function ServiceDispatchHandler(options) {
         '*~hyperbahn~ad': true,
         '*~hyperbahn~relay-ad': true
     };
-    self.circuitsCodeName = 'Declined';
+    self.circuitsCodeNames = {};
     self.circuits = null;
 
     self.rateLimiter = new RateLimiter({
@@ -1504,18 +1504,18 @@ function initCircuits() {
         egressNodes: self.egressNodes,
         config: self.circuitsConfig,
         shorts: self.circuitShorts,
-        codeName: self.circuitsCodeName
+        codeNamesTable: self.circuitsCodeNames
     });
 };
 
-ServiceDispatchHandler.prototype.updateCircuitCodeName =
-function updateCircuitCodeName(codeName) {
+ServiceDispatchHandler.prototype.updateCircuitCodeNames =
+function updateCircuitCodeNames(codeNames) {
     var self = this;
 
-    self.circuitsCodeName = codeName;
+    self.circuitsCodeNames = codeNames;
 
     if (self.circuits) {
-        self.circuits.updateCodeName(codeName);
+        self.circuits.updateCodeNames(codeNames);
     }
 };
 

--- a/test/circuits/happy-path.js
+++ b/test/circuits/happy-path.js
@@ -97,7 +97,9 @@ allocCluster.test('request circuit state from endpoint', {
     remoteConfig: {
         'rateLimiting.enabled': false,
         'circuits.enabled': true,
-        'circuits.codeName': 'Unhealthy',
+        'circuits.codeNames': {
+            '*~*~*': 'Unhealthy'
+        },
         'partialAffinity.enabled': true
     },
     seedConfig: {

--- a/test/lib/relay-network.js
+++ b/test/lib/relay-network.js
@@ -181,6 +181,7 @@ RelayNetwork.prototype.setCluster = function setCluster(cluster) {
             rateLimiterEnabled: self.rateLimiterEnabled,
             circuitsConfig: self.circuitsConfig
         });
+        relayChannel.handler.updateCircuitCodeName('Unhealthy');
 
         var hyperbahnChannel = relayChannel.makeSubChannel({
             serviceName: 'hyperbahn'

--- a/test/lib/relay-network.js
+++ b/test/lib/relay-network.js
@@ -181,7 +181,9 @@ RelayNetwork.prototype.setCluster = function setCluster(cluster) {
             rateLimiterEnabled: self.rateLimiterEnabled,
             circuitsConfig: self.circuitsConfig
         });
-        relayChannel.handler.updateCircuitCodeName('Unhealthy');
+        relayChannel.handler.updateCircuitCodeNames({
+            '*~*~*': 'Unhealthy'
+        });
 
         var hyperbahnChannel = relayChannel.makeSubChannel({
             serviceName: 'hyperbahn'


### PR DESCRIPTION
This changes the CircuitBreaker to return an Unhealth
error frame instead of a Declined error frame.

This will:

 - Stop retries on circuit broken; to avoid retry storm
 - Make graphs a bit nicer because Unhealthy is only
	used by circuit breaker.

r: @rf @kriskowal @jcorbin