### PR TITLE
Improve consistency in the set-k test

### DIFF
--- a/test/forward/set-k.js
+++ b/test/forward/set-k.js
@@ -45,6 +45,16 @@ allocCluster.test('set k and forward', {
             return assert.end(err);
         }
 
+        cluster.sendRegister(steve.channel, {
+            serviceName: steve.serviceName
+        }, onceConnected);
+    }
+
+    function onceConnected(err) {
+        if (err) {
+            return assert.end(err);
+        }
+
         cluster.checkExitKValue(assert, {
             serviceName: steve.serviceName,
             kValue: 15


### PR DESCRIPTION
Since full connection consequences of K-changes (whether internal or by
remoteConfig) are only implemented after the next advertise cycle.