### PR TITLE
Factor TestCluster#untilExitsConnectedExcept out of #untilExitsConnected

### DIFF
--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -583,6 +583,12 @@ TestCluster.prototype.checkExitKValue = function checkExitKValue(assert, opts) {
 TestCluster.prototype.untilExitsConnected =
 function untilExitsConnected(serviceName, channel, callback) {
     var self = this;
+    self.untilExitsConnectedExcept(serviceName, channel, {}, callback);
+};
+
+TestCluster.prototype.untilExitsConnectedExcept =
+function untilExitsConnectedExcept(serviceName, channel, except, callback) {
+    var self = this;
 
     var app = self.apps[0];
 
@@ -591,7 +597,9 @@ function untilExitsConnected(serviceName, channel, callback) {
     var pending = {};
     for (var i = 0; i < exitKeys.length; ++i) {
         var exitKey = exitKeys[i];
-        pending[exitKey] = true;
+        if (!except[exitKey]) {
+            pending[exitKey] = true;
+        }
     }
 
     // Check for all future connections

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -587,7 +587,12 @@ function untilExitsConnected(serviceName, channel, callback) {
     var app = self.apps[0];
 
     var exits = app.clients.egressNodes.exitsFor(serviceName);
-    var numExits = Object.keys(exits).length;
+    var exitKeys = Object.keys(exits);
+    var pending = {};
+    for (var i = 0; i < exitKeys.length; ++i) {
+        var exitKey = exitKeys[i];
+        pending[exitKey] = true;
+    }
 
     // Check for all future connections
     channel.connectionEvent.on(onConn);
@@ -610,15 +615,13 @@ function untilExitsConnected(serviceName, channel, callback) {
             newConn.identifiedEvent.removeListener(checkConns);
         }
 
-        var got = {};
         forEachPeerConn(channel, function each(conn, peer) {
             if (exits[peer.hostPort] !== undefined && conn.direction === 'in') {
-                got[peer.hostPort] = true;
+                delete pending[peer.hostPort];
             }
         });
 
-        var gotExits = Object.keys(got).length;
-        if (gotExits >= numExits) {
+        if (!Object.keys(pending).length) {
             finish();
         }
     }

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -593,13 +593,11 @@ function untilExitsConnected(serviceName, channel, callback) {
     channel.connectionEvent.on(onConn);
 
     // Check for all existing non-identified connections
-    var keys = Object.keys(channel.serverConnections);
-    for (var k = 0; k < keys.length; k++) {
-        var connection = channel.serverConnections[keys[k]];
+    forEachServerConn(channel, function each(connection) {
         if (!connection.remoteName) {
             connection.identifiedEvent.on(checkConns);
         }
-    }
+    });
 
     checkConns();
 
@@ -806,3 +804,11 @@ function forEachHostPort(each) {
         each('namedRemote', i, self.namedRemotes[i].hostPort);
     }
 };
+
+function forEachServerConn(channel, each) {
+    var keys = Object.keys(channel.serverConnections);
+    for (var i = 0; i < keys.length; i++) {
+        var conn = channel.serverConnections[keys[i]];
+        each(conn);
+    }
+}

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -611,17 +611,11 @@ function untilExitsConnected(serviceName, channel, callback) {
         }
 
         var got = {};
-
-        var peers = channel.peers.values();
-        for (var i = 0; i < peers.length; i++) {
-            var peer = peers[i];
-            for (var j = 0; j < peer.connections.length; j++) {
-                var conn = peer.connections[j];
-                if (exits[peer.hostPort] !== undefined && conn.direction === 'in') {
-                    got[peer.hostPort] = true;
-                }
+        forEachPeerConn(channel, function each(conn, peer) {
+            if (exits[peer.hostPort] !== undefined && conn.direction === 'in') {
+                got[peer.hostPort] = true;
             }
-        }
+        });
 
         var gotExits = Object.keys(got).length;
         if (gotExits >= numExits) {
@@ -810,5 +804,16 @@ function forEachServerConn(channel, each) {
     for (var i = 0; i < keys.length; i++) {
         var conn = channel.serverConnections[keys[i]];
         each(conn);
+    }
+}
+
+function forEachPeerConn(channel, each) {
+    var peers = channel.peers.values();
+    for (var i = 0; i < peers.length; i++) {
+        var peer = peers[i];
+        for (var j = 0; j < peer.connections.length; j++) {
+            var conn = peer.connections[j];
+            each(conn, peer);
+        }
     }
 }


### PR DESCRIPTION
Will be needed by `test/register/with-ringpop-divergence.js` to make its
expectations explicit under deferred connection initialization.

Did in passing cleanup by factoring out some `forEach`* utilities since we had
hit critical mass on index-variable collision.