### PR TITLE
service-proxy: emit recvd stat if rejecting frame

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -398,7 +398,7 @@ function handleLazily(conn, reqFrame) {
             if (routingDelegate) {
                 self.rejectRequestFrame(conn, reqFrame, 'Busy', 'Routing delegate ' + routingDelegate + ' is rate-limited by the service rps of ' + serviceLimit);
             } else {
-                self.rejectRequestFrame(conn, reqFrame, 'Busy', 'Busy', serviceName + ' is rate-limited by the service rps of ' + serviceLimit);
+                self.rejectRequestFrame(conn, reqFrame, 'Busy', serviceName + ' is rate-limited by the service rps of ' + serviceLimit);
             }
             return true;
         }

--- a/test/forward/forwarding-to-down-server.js
+++ b/test/forward/forwarding-to-down-server.js
@@ -93,7 +93,8 @@ allocCluster.test('forwarding to a down service', {
                 cassert.equal(logLine.meta.serviceName, 'steve',
                     'expected steve error');
             } else if (logLine.msg === 'Refreshing service peer affinity' ||
-                       logLine.msg === 'implementing affinity change') {
+                       logLine.msg === 'implementing affinity change' ||
+                       logLine.msg === 'connecting peers') {
                 cassert.ok(true, 'expected partial affinity logs');
             } else if (logLine.msg === 'error while forwarding' ||
                        logLine.msg === 'resetting connection') {

--- a/test/forward/stats-for-rate-limited-requests.js
+++ b/test/forward/stats-for-rate-limited-requests.js
@@ -42,6 +42,9 @@ allocCluster.test('requesting rate limited to cluster', {
     cluster.logger.whitelist(
         'warn', 'forwarding error frame'
     );
+    cluster.logger.whitelist(
+        'info', 'connecting peers'
+    );
 
     var steve = cluster.remotes.steve;
     var bob = cluster.remotes.bob;
@@ -145,6 +148,9 @@ allocCluster.test('requesting rate limited to one host', {
     cluster.logger.whitelist(
         'info', 'hyperbahn node is rate-limited by the total rps limit'
     );
+    cluster.logger.whitelist(
+        'info', 'connecting peers'
+    );
 
     var steve = cluster.remotes.steve;
     var bob = cluster.remotes.bob;
@@ -213,6 +219,17 @@ allocCluster.test('requesting rate limited to one host', {
 
         var allStats = statsByType(stats);
         var latencies = allStats['tchannel.inbound.calls.latency'];
+
+        var recvdStats = allStats['tchannel.inbound.calls.recvd'];
+        var echoRecvd = [];
+
+        for (i = 0; i < recvdStats.length; i++) {
+            if (recvdStats[i].tags.endpoint === 'echo') {
+                echoRecvd.push(recvdStats[i]);
+            }
+        }
+
+        assert.equal(echoRecvd.length, 100, 'expected 100 recvd');
 
         var echoLatencies = [];
         for (i = 0; i < latencies.length; i++) {

--- a/test/forward/stats-for-rate-limited-requests.js
+++ b/test/forward/stats-for-rate-limited-requests.js
@@ -23,6 +23,7 @@
 var CollapsedAssert = require('../lib/collapsed-assert.js');
 var allocCluster = require('../lib/test-cluster.js');
 
+/*eslint max-statements: [2, 40]*/
 allocCluster.test('requesting rate limited to cluster', {
     size: 5,
     remoteConfig: {

--- a/test/lib/test-cluster.js
+++ b/test/lib/test-cluster.js
@@ -145,6 +145,7 @@ function TestCluster(opts) {
     }
 
     self.logger.whitelist('info', 'implementing affinity change');
+    self.logger.whitelist('info', 'connecting peers');
 }
 inherits(TestCluster, EventEmitter);
 


### PR DESCRIPTION
We had a bug where customers saw more errors then
recvd.

This is because the recvd stat is emitted by either:

 - RelayHandler
 - EndpointHandler

When we reject a request due to rate limiter or
circuit breaker we increment latency & error but do
not increment recvd

r: @jcorbin @rf @kriskowal