### PR TITLE
Cleanup ServiceProxy#refreshServicePeerPartially for perf analysis

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -815,12 +815,20 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
         return;
     }
 
+    self.addNewPartialPeer(serviceChannel, hostPort, now);
+};
+
+ServiceDispatchHandler.prototype.addNewPartialPeer =
+function addNewPartialPeer(serviceChannel, hostPort, now) {
+    var self = this;
+
+    var serviceName = serviceChannel.serviceName;
     var partialRange = self.partialRanges[serviceName];
     if (partialRange) {
         partialRange.addWorker(hostPort, now);
     }
 
-    peer = self._getServicePeer(serviceChannel, hostPort);
+    self._getServicePeer(serviceChannel, hostPort);
 
     // Unmark recently seen peers, so they don't get reaped
     deleteIndexEntry(self.peersToReap, hostPort, serviceName);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -809,13 +809,12 @@ function refreshServicePeerPartially(serviceName, hostPort, now) {
     var serviceChannel = self.getServiceChannel(serviceName, false);
     var peer = serviceChannel.peers.get(hostPort);
 
-    // simply freshen if not new
-    if (peer) {
+    if (!peer) {
+        self.addNewPartialPeer(serviceChannel, hostPort, now);
+    } else {
+        // simply freshen if not new
         self.freshenPartialPeer(peer, serviceName, now);
-        return;
     }
-
-    self.addNewPartialPeer(serviceChannel, hostPort, now);
 };
 
 ServiceDispatchHandler.prototype.addNewPartialPeer =

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -827,7 +827,11 @@ function addNewPartialPeer(serviceChannel, hostPort, now) {
         partialRange.addWorker(hostPort, now);
     }
 
-    self._getServicePeer(serviceChannel, hostPort);
+    var peer = serviceChannel.peers.add(hostPort);
+    if (!peer.serviceProxyServices) {
+        peer.serviceProxyServices = {};
+    }
+    peer.serviceProxyServices[serviceName] = true;
 
     // Unmark recently seen peers, so they don't get reaped
     deleteIndexEntry(self.peersToReap, hostPort, serviceName);


### PR DESCRIPTION
In most recent flame graph under canary test:
- this method took ~19% of process time
- most of that 19% was due to an anonymous function that was the alternate to freshenPartialPeer

Hopefully this will provide us more clarity once / if we get down to tuning this path.

r @rf @Raynos 