### PR TITLE
Correctly handle rpsLimits set to zero...

### DIFF
--- a/rate_limiter.js
+++ b/rate_limiter.js
@@ -439,7 +439,7 @@ function shouldRateLimitService(serviceName) {
     }
     var counter = self.serviceCounters[serviceName];
     assert(counter, 'cannot find counter for ' + serviceName);
-    var result = counter.rps > counter.rpsLimit;
+    var result = counter.rpsLimit > 0 && counter.rps > counter.rpsLimit;
     if (result) {
         self.batchStats.pushStat(
             'tchannel.rate-limiting.service-busy',
@@ -459,7 +459,7 @@ function shouldKillSwitchService(serviceName) {
     }
     var counter = self.ksCounters[serviceName];
     assert(counter, 'cannot find kill-switch counter for ' + serviceName);
-    var result = counter.rps > counter.rpsLimit;
+    var result = counter.rpsLimit > 0 && counter.rps > counter.rpsLimit;
     if (result) {
         self.batchStats.pushStat(
             'tchannel.rate-limiting.service-kill-switched',
@@ -476,7 +476,9 @@ function shouldRateLimitTotalRequest(serviceName) {
     var self = this;
     var result;
     if (!serviceName || self.exemptServices.indexOf(serviceName) === -1) {
-        result = self.totalRequestCounter.rps > self.totalRequestCounter.rpsLimit;
+        result =
+            self.totalRequestCounter.rpsLimit > 0 &&
+            self.totalRequestCounter.rps > self.totalRequestCounter.rpsLimit;
     } else {
         result = false;
     }
@@ -498,7 +500,9 @@ function shouldKillSwitchTotalRequest(serviceName) {
     var self = this;
     var result;
     if (!serviceName || self.exemptServices.indexOf(serviceName) === -1) {
-        result = self.totalKsCounter.rps > self.totalKsCounter.rpsLimit;
+        result =
+            self.totalKsCounter.rpsLimit > 0 &&
+            self.totalKsCounter.rps > self.totalKsCounter.rpsLimit;
     } else {
         result = false;
     }

--- a/test/admin/rate-limiter.js
+++ b/test/admin/rate-limiter.js
@@ -25,7 +25,11 @@ var Admin = require('../../bin/admin.js');
 var allocCluster = require('../lib/test-cluster.js');
 
 allocCluster.test('disable rate limiter and forward', {
-    size: 3
+    size: 3,
+    whitelist: [
+        ['info', 'hyperbahn service is rate-limited by the service rps limit'],
+        ['info', 'hyperbahn node is rate-limited by the total rps limit']
+    ]
 }, function t(cluster, assert) {
     var bob = cluster.remotes.bob;
 
@@ -72,6 +76,10 @@ allocCluster.test('disable rate limiter and forward', {
 
 allocCluster.test('set total rate limiter and forward', {
     size: 1,
+    whitelist: [
+        ['info', 'hyperbahn service is rate-limited by the service rps limit'],
+        ['info', 'hyperbahn node is rate-limited by the total rps limit']
+    ],
     remoteConfig: {
         'rateLimiting.enabled': true,
         'rateLimiting.totalRpsLimit': 0,
@@ -126,6 +134,10 @@ allocCluster.test('set total rate limiter and forward', {
 
 allocCluster.test('set service rate limiter and forward', {
     size: 1,
+    whitelist: [
+        ['info', 'hyperbahn service is rate-limited by the service rps limit'],
+        ['info', 'hyperbahn node is rate-limited by the total rps limit']
+    ],
     remoteConfig: {
         'rateLimiting.enabled': true,
         'rateLimiting.totalRpsLimit': 1000,
@@ -189,6 +201,10 @@ allocCluster.test('set service rate limiter and forward', {
 
 allocCluster.test('set exempt service and forward', {
     size: 2,
+    whitelist: [
+        ['info', 'hyperbahn service is rate-limited by the service rps limit'],
+        ['info', 'hyperbahn node is rate-limited by the total rps limit']
+    ],
     remoteConfig: {
         'rateLimiting.enabled': true,
         'rateLimiting.totalRpsLimit': 1000,


### PR DESCRIPTION
...by effectively disabling rate limits.

I noticed that our test suite at least was provoking rate limiting for total
rps limit set to 0.  Whether or not the tests should be running with rps limit
0, I feel this is more correct implementation.

r @raynos @rf