### PR TITLE
Add staleness checking for partial affinity workers

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -816,16 +816,16 @@ function addNewPartialPeer(serviceChannel, hostPort, now) {
     var self = this;
 
     var serviceName = serviceChannel.serviceName;
-    var partialRange = self.partialRanges[serviceName];
-    if (partialRange) {
-        partialRange.addWorker(hostPort, now);
-    }
-
     var peer = serviceChannel.peers.add(hostPort);
     if (!peer.serviceProxyServices) {
         peer.serviceProxyServices = {};
     }
     peer.serviceProxyServices[serviceName] = true;
+
+    var partialRange = self.partialRanges[serviceName];
+    if (partialRange) {
+        partialRange.addWorker(hostPort, now);
+    }
 
     // Unmark recently seen peers, so they don't get reaped
     deleteIndexEntry(self.peersToReap, hostPort, serviceName);

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1671,6 +1671,10 @@ function compute() {
     this.connectedPeers = this.proxy.connectedServicePeers[this.serviceChannel.serviceName] || null;
     this.connectedPeerKeys = this.connectedPeers ? Object.keys(this.connectedPeers) : [];
 
+    this.toConnect = [];
+    this.toDisconnect = [];
+    this.isAffine = {};
+
     for (i = 0; i < this.partialRange.affineWorkers.length; i++) {
         worker = this.partialRange.affineWorkers[i];
         this.isAffine[worker] = true;

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1647,6 +1647,9 @@ function AffinityChange(proxy, serviceChannel, partialRange, now) {
     this.toDisconnect = [];
     this.isAffine = {};
 
+    this.connectedPeers = null;
+    this.connectedPeerKeys = [];
+
     this.compute();
 }
 
@@ -1661,23 +1664,24 @@ AffinityChange.prototype.compute =
 function compute() {
     this.partialRange.computeIfNeeded();
 
-    var connectedPeers = this.proxy.connectedServicePeers[this.serviceChannel.serviceName];
-    var connectedPeerKeys = connectedPeers ? Object.keys(connectedPeers) : [];
     var i;
     var worker;
     var peer;
+
+    this.connectedPeers = this.proxy.connectedServicePeers[this.serviceChannel.serviceName] || null;
+    this.connectedPeerKeys = this.connectedPeers ? Object.keys(this.connectedPeers) : [];
 
     for (i = 0; i < this.partialRange.affineWorkers.length; i++) {
         worker = this.partialRange.affineWorkers[i];
         this.isAffine[worker] = true;
         peer = this.serviceChannel.peers.get(worker);
-        if (!(connectedPeers && connectedPeers[worker]) || !(peer && peer.isConnected('out'))) {
+        if (!(this.connectedPeers && this.connectedPeers[worker]) || !(peer && peer.isConnected('out'))) {
             this.toConnect.push(worker);
         }
     }
 
-    for (i = 0; i < connectedPeerKeys.length; i++) {
-        worker = connectedPeerKeys[i];
+    for (i = 0; i < this.connectedPeerKeys.length; i++) {
+        worker = this.connectedPeerKeys[i];
         if (!this.isAffine[worker] && !this.proxy.peersToPrune[worker]) {
             this.toDisconnect.push(worker);
         }

--- a/test/peer-churn.js
+++ b/test/peer-churn.js
@@ -63,6 +63,9 @@ allocCluster.test('peer churn', {
         // XXX do we care about the rare:
         // AUTOBAHN INFO: ignoring outresponse.send on a closed connection ~ { responseId: 5,
 
+        ['warn', 'affinity change failed audit'],
+        ['warn', 'removing stale partial affinity worker'],
+
         ['info', 'reaping dead peers'],
         ['info', 'reaping dead peer'],
         ['info', 'draining peer'],
@@ -143,6 +146,10 @@ allocCluster.test('peer churn', {
 
         checkAllLogs(cluster, assert, function checkEachLog(record) {
             assert.ok([
+                // TODO: this is a bug parlayed into a warning
+                'affinity change failed audit',
+                'removing stale partial affinity worker',
+
                 // happens for destructive shutdown
                 'reaping dead peers',
                 'Failed to register to hyperbahn for remote',


### PR DESCRIPTION
Rather than always create peers by side-effect, check the partialRange.workers
against actual serviceChannel peeers, remove stale ones, and log loudly about
it.