### PR TITLE
Fix bug in PartialRange#removeWorker

### DIFF
--- a/partial_range.js
+++ b/partial_range.js
@@ -99,7 +99,7 @@ function removeWorker(hostPort, now) {
         return;
     }
 
-    this.workers.splice(i, 0); // XXX swap-out? sliceNconcat?
+    this.workers.splice(i, 1); // XXX swap-out? sliceNconcat?
     this.recompute(now);
 };
 


### PR DESCRIPTION
Previously it never did any such thing.

Bug revealed by the upcoming staleness auditing (#261) under the recently added
peer churn test with partial affinity enabled.