### PR TITLE
allow recvd requests for debugging

### DIFF
--- a/clients/batch-stats.js
+++ b/clients/batch-stats.js
@@ -60,12 +60,12 @@ function handleStat(stat) {
     }
 
     if (
-        stat.name === 'tchannel.inbound.calls.latency'
+        stat.name === 'tchannel.inbound.calls.latency' ||
+        stat.name === 'tchannel.inbound.calls.recvd'
     ) {
         self.writeToStatsd(self.statsd.globalClient, stat);
         self.writeToStatsd(self.statsd.perWorkerClient, stat);
     } else if (
-        stat.name === 'tchannel.inbound.calls.recvd' ||
         stat.name === 'tchannel.inbound.request.size' ||
         stat.name === 'tchannel.inbound.request.size' ||
         stat.name === 'tchannel.inbound.calls.system-errors' ||


### PR DESCRIPTION
This will allow us to update the `hyperbahn-worker` dashboard
and see all recvd requests for that istance.

This will help debug latency issues and event loop lag issues

r: @jcorbin @rf