### PR TITLE
service-proxy: loop over service keys instead

### DIFF
--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1400,8 +1400,9 @@ function reapSinglePeer(hostPort, serviceNames, now) {
         peer.clearDrain('superceded by peer reap');
     }
 
-    for (var i = 0; i < serviceNames.length; i++) {
-        var serviceName = serviceNames[i];
+    var serviceKeys = Object.keys(serviceNames);
+    for (var i = 0; i < serviceKeys.length; i++) {
+        var serviceName = serviceKeys[i];
         var serviceChannel = self.getServiceChannel(serviceName);
         if (serviceChannel) {
             serviceChannel.peers.delete(hostPort);
@@ -1425,7 +1426,7 @@ function reapSinglePeer(hostPort, serviceNames, now) {
         'reaping dead peer',
         self.extendLogInfo(
             peer.extendLogInfo(peer.draining.extendLogInfo({
-                serviceNames: serviceNames
+                serviceKeys: serviceKeys
             }))
         )
     );

--- a/service-proxy.js
+++ b/service-proxy.js
@@ -1369,7 +1369,7 @@ function pruneSinglePeer(hostPort, pruneInfo) {
 };
 
 ServiceDispatchHandler.prototype.reapSinglePeer =
-function reapSinglePeer(hostPort, serviceNames, now) {
+function reapSinglePeer(hostPort, serviceTimes, now) {
     var self = this;
 
     if (self.knownPeers[hostPort]) {
@@ -1400,9 +1400,9 @@ function reapSinglePeer(hostPort, serviceNames, now) {
         peer.clearDrain('superceded by peer reap');
     }
 
-    var serviceKeys = Object.keys(serviceNames);
-    for (var i = 0; i < serviceKeys.length; i++) {
-        var serviceName = serviceKeys[i];
+    var serviceNames = Object.keys(serviceTimes);
+    for (var i = 0; i < serviceNames.length; i++) {
+        var serviceName = serviceNames[i];
         var serviceChannel = self.getServiceChannel(serviceName);
         if (serviceChannel) {
             serviceChannel.peers.delete(hostPort);
@@ -1426,7 +1426,7 @@ function reapSinglePeer(hostPort, serviceNames, now) {
         'reaping dead peer',
         self.extendLogInfo(
             peer.extendLogInfo(peer.draining.extendLogInfo({
-                serviceKeys: serviceKeys
+                serviceNames: serviceNames
             }))
         )
     );


### PR DESCRIPTION
This is a nasty bug where we did not delete peers
in the reaper.

We accidentally "loop" over an object...

This also fixes an elk issue where we are exploding
their key space with {serviceName} dimension.

r: @rf @kriskowal @jcorbin