### PR TITLE
Upgrade to TChannel 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
-    "tchannel": "^3.6.24",
+    "tchannel": "^3.7.0",
     "uber-statsd-client": "1.4.0",
     "uncaught-exception": "6.0.2",
     "xtend": "4.0.0"


### PR DESCRIPTION
Upgrades TChannel for production validation. Works around an uncaught exception when sending error frames on a reclaimed lazy relay request. Allows optional arguments flag can be threaded through TChannel, but Hyperbahn should make no use of this at this time.