### PR TITLE
Add subchannel update damper

### DIFF
--- a/clients/index.js
+++ b/clients/index.js
@@ -468,6 +468,7 @@ function onRemoteConfigUpdate(changedKeys, forceUpdate) {
     self.updatePartialAffinityEnabled(hasChanged, forceUpdate);
     self.setMaximumRelayTTL(hasChanged, forceUpdate);
     self.updatePeerHeapEnabled(hasChanged, forceUpdate);
+    self.updateMinUpdatePeriod(hasChanged, forceUpdate);
 };
 
 ApplicationClients.prototype.setSocketInspector =
@@ -614,6 +615,15 @@ function updateConnectPeersPeriod(hasChanged, forceUpdate) {
     if (forceUpdate || hasChanged['peerConnecter.period']) {
         var period = self.remoteConfig.get('peerConnecter.period', 100);
         self.serviceProxy.setConnectPeersPeriod(period);
+    }
+};
+
+ApplicationClients.prototype.updateMinUpdatePeriod =
+function updateMinUpdatePeriod(hasChanged, forceUpdate) {
+    var self = this;
+    if (forceUpdate || hasChanged['minUpdate.period']) {
+        var period = self.remoteConfig.get('minUpdate.period', 0);
+        self.serviceProxy.minUpdatePeriod = period;
     }
 };
 


### PR DESCRIPTION
This adds a configurable option for ServiceProxy to debounce requests to update service channels by a minimum period (default 0). The period can be altered by an external agent (remote configuration).

The updateServiceChannels function is not covered by our tests currently. None of our tests appear to exercise ring changes.

Without configuring the min update period, this retains the current behavior, except using setTimeout instead of setImmediately, effectively introducing an implicit minimum delay of 4ms.

r @Raynos 