### PR TITLE
In case of emergecy, raise ping req timeout

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,7 @@
     "clients.graphite": null,
 
     "hyperbahn.ringpop.timeouts": {
-        "pingReqTimeout": 5000,
+        "pingReqTimeout": 8000,
         "pingTimeout": 1500,
         "joinTimeout": 1000
     },


### PR DESCRIPTION
I’ve prepared this branch so that we can raise the ping req timeout if latency over Hyperbahn becomes too great with our current deployment size.

cc @raynos